### PR TITLE
Output FOP and XEP version (with option -version)

### DIFF
--- a/lib/daps_functions
+++ b/lib/daps_functions
@@ -651,9 +651,11 @@ function call_make {
         # PDF
         printf "%${COLWIDTH}s: %s\n" "PDF FORMATTER" "$FORMATTER"
         if [[ "fop" = "$FORMATTER" ]]; then
+            printf "%${COLWIDTH}s: %s\n" "FORMATTER VERSION" "$(fop -version)"
             printf "%${COLWIDTH}s: %s\n" "FORMATTER WRAPPER" "$FOP_WRAPPER"
             printf "%${COLWIDTH}s: %s\n" "FORMATTER CONFIG" "$FOP_CONFIG_FILE"
         elif [[ "xep" = "$FORMATTER" ]]; then
+            printf "%${COLWIDTH}s: %s\n" "FORMATTER VERSION" "$(xep -version)"
             printf "%${COLWIDTH}s: %s\n" "FORMATTER WRAPPER" "$XEP_WRAPPER"
             printf "%${COLWIDTH}s: %s\n" "FORMATTER CONFIG:" "$XEP_CONFIG_FILE"
         fi


### PR DESCRIPTION
As FOP (and XEP) can have different versions, I think it is very useful to have them printed when `-v` is active.

The following commit adds an additional line in the output (see "FORMATTER VERSION"):

```
        DAPS VERSION: @PACKAGE_VERSION@
[...]
       PDF FORMATTER: fop
   FORMATTER VERSION: FOP Version 2.2
   FORMATTER WRAPPER: /local/doc/daps/libexec/daps-fop
    FORMATTER CONFIG:
```

@fsundermeyer I'm not sure if this is the correct style, so please review. Thanks!