### PR TITLE
Modernized get-language.xsl

### DIFF
--- a/daps-xslt/common/get-language.xsl
+++ b/daps-xslt/common/get-language.xsl
@@ -4,7 +4,9 @@
      Extract language from @lang or @xml:lang attributes
      
    Parameters:
-     None
+     * allowed.roots (string)
+       String of allowed root elements, separated by spaces.
+       Use the local name (without any namespace prefixes).
        
    Input:
      DocBook 4 or DocBook 5 documents with book, article, or
@@ -25,38 +27,42 @@
 
 <xsl:output method="text"/>
 
+<xsl:param name="allowed.roots">appendix article bibliography book chapter
+ glossary glossdiv part preface qandaset reference refsect1 refsect2 refsect3
+ refsection sect1 sect2 sect3 sect4 sect5 section set</xsl:param>
+
+
 <xsl:template match="/">
+   <xsl:variable name="root" select="local-name(*[1])"/>
+   <xsl:variable name="id" select="(*[1]/@xml:id|*[1]/@id)[1]"/>
+
    <xsl:choose>
-     <xsl:when test="book or article or set or chapter">
-       <xsl:apply-templates select="book|article|set"/>
-     </xsl:when>
-     <xsl:when test="db:book or db:article or db:set or db:chapter">
-       <xsl:apply-templates select="db:book|db:article|db:set"/>
+     <xsl:when test="contains($allowed.roots, $root)">
+       <xsl:apply-templates />
      </xsl:when>
      <xsl:otherwise>
        <xsl:message terminate="yes">
-         <xsl:text>ERROR: Root Element is not a set, book, article or chapter!&#10;</xsl:text>
-         <xsl:text>       Found </xsl:text>
+         <xsl:text>ERROR: Inappropriate root element! Allowed elements are:&#10;       </xsl:text>
+         <xsl:value-of select="normalize-space($allowed.roots)"/>
+         <xsl:text>&#10;       Found </xsl:text>
          <xsl:value-of select="name(*[1])"/>
+         <xsl:if test="$id != ''">
+          <xsl:text> with id=</xsl:text>
+          <xsl:value-of select="$id"/>
+         </xsl:if>
        </xsl:message>
      </xsl:otherwise>
    </xsl:choose>
 </xsl:template>
 
-<xsl:template match="db:book|db:article|db:set">
-  <xsl:call-template name="getlanguage"/>
-</xsl:template>
 
-<xsl:template match="book|article|set|chapter" name="getlanguage">
+<xsl:template match="/*">
+ <xsl:variable name="lang" select="(@xml:lang|@lang)[1]"/>
    <xsl:choose>
-    <xsl:when test="@lang">
-     <xsl:value-of select="@lang"/>
+    <xsl:when test="$lang != ''">
+     <xsl:value-of select="$lang"/>
      <xsl:text>&#10;</xsl:text>
     </xsl:when>
-     <xsl:when test="@xml:lang">
-       <xsl:value-of select="@xml:lang"/>
-     <xsl:text>&#10;</xsl:text>
-     </xsl:when>
     <xsl:otherwise>
      <xsl:message terminate="yes">ERROR: Element '<xsl:value-of select="name()"/>' doesn't contain attribute lang!</xsl:message>
     </xsl:otherwise>


### PR DESCRIPTION
### Background
The stylesheet `get-language.xsl` (as the name implies) returns the language of a DocBook's root element. For "safety" reasons, we had a check that allows only valid root elements like article, chapter, book, or set. This should avoid building of single paras, for example.

However, the DocBook XSL stylesheets are capable of rendering much more elements. As we also maybe want to build glossaries or references from time to time, I've extended this list and introduced a new parameter. This makes it also possible to define it at runtime if wanted.

### Changes
This PR contains:

* Introduce parameter `allowed.roots`: makes it easier to limit or extend the allowed root element names
* Simplify template rules: no prefixes are needed anymore, makes code lean and clean 😉
* Output `@id` or `@xml:id` when (if available) we encounter a root element which isn't allowed in $allowed.roots
* Widen the list of possible root elements

@fsundermeyer I don't think it will introduce any problems, but it is always good to have a second pair of eyes. 😉 