### PR TITLE
Ignore non-unique xml:id

### DIFF
--- a/.travis-debug
+++ b/.travis-debug
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-echo "PATH=$PATH"
-ls
+TESTDIR=test/xml-syntax-check
+
+echo -n "Running daps XML syntax check for double IDs..."
+./libexec/daps-xmlwellformed $TESTDIR/double-ids.xml && echo "ok" || echo "Failed"
+
+echo -n "Running daps XML syntax check for XML file with syntax errors..."
+./libexec/daps-xmlwellformed $TESTDIR/syntax-error.xml 2>/dev/null && echo "Failed" || echo "ok"
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,13 @@ before_install:
     - git clone https://github.com/openSUSE/suse-xsl.git suse
 
 install:
-    - ./.travis-debug
     - ./configure --sysconfdir=/etc
     - make
     - sudo make install
 
 script:
     # - make test
+    - ./.travis-debug
     - echo "Done"
 
 # blacklist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: bash
 
+# Ubuntu version
+dist: xenial
+
 # Cache Ubuntu packages:
 cache: apt
 

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -10,6 +10,7 @@
 
 import argparse
 import sys
+import textwrap
 from lxml import etree
 
 __author__ = "Thomas Schraitle"
@@ -31,8 +32,9 @@ def check_wellformedness(xmlfile, xinclude=True):
         if xinclude:
             xml.xinclude()
         return 0
-    except etree.XMLSyntaxError as err:
-        print(err, file=sys.stderr)
+    except (etree.XMLSyntaxError, etree.XIncludeError) as err:
+        print("ERROR: %s" % err, file=sys.stderr)
+        print(textwrap.indent(str(err.error_log), prefix="       "), file=sys.stderr)
         return 10
 
 
@@ -55,7 +57,7 @@ def parse_cli(args=None):
                         help="XML file to check well-formedness"
                         )
     args = parser.parse_args(args)
-    print(args, file=sys.stderr)
+    # print(args, file=sys.stderr)
     return args
 
 

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -8,16 +8,24 @@
 * Ignores non-unique IDs (attribute xml:id's)
 """
 
+__author__ = "Thomas Schraitle"
+
 import argparse
 import sys
 import textwrap
 from lxml import etree
 
-__author__ = "Thomas Schraitle"
+
+if etree.LXML_VERSION < (3, 4, 0):
+    print("ERROR: I need a minimum version of 3.4.0 of lxml.",
+          file=sys.stderr)
+    sys.exit(10)
 
 
 def check_wellformedness(xmlfile, xinclude=True):
     """Checks a file for well-formedness
+
+    This only works with lxml >= 3.4.0 (because of collect_ids option)
 
     :param str xmlfile: filename to XML file
     :param bool xinclude: do xinclude processing (default: True) or not
@@ -31,6 +39,7 @@ def check_wellformedness(xmlfile, xinclude=True):
         tree = etree.parse(xmlfile, parser=xmlparser)
         if xinclude:
             tree.xinclude()
+            # HACK for lxml < v4.2.1:
             # This test is needed to perform XInclude resolution on
             # second and third levels:
             if list(tree.iter("{http://www.w3.org/2001/XInclude}include")):

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# This script was needed as xmllint cannot ignore double xml:ids
+#
+"""Performs a well-formedness check on XML.
+
+* Does XInclude processing before any checks;
+* Ignores non-unique IDs (attribute xml:id's)
+"""
+
+import argparse
+import sys
+from lxml import etree
+
+__author__ = "Thomas Schraitle"
+
+
+def check_wellformedness(xmlfile, xinclude=True):
+    """Checks a file for well-formedness
+
+    :param str xmlfile: filename to XML file
+    :param bool xinclude: do xinclude processing (default: True) or not
+    :return: 0 (everything ok) or != 0 (some problem)
+    :rtype: int
+    """
+    # We don't want to collect all IDs to avoid problems when
+    # IDs are non-unique:
+    xmlparser = etree.XMLParser(collect_ids=False)
+    try:
+        xml = etree.parse(xmlfile, parser=xmlparser)
+        if xinclude:
+            xml.xinclude()
+        return 0
+    except etree.XMLSyntaxError as err:
+        print(err, file=sys.stderr)
+        return 10
+
+
+def parse_cli(args=None):
+    """Parse CLI arguments
+
+    :param list args: Use the list or sys.args
+    :return: parsed arguments
+    :rtype: :class:`argparse.Namespace`
+    """
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0],
+                                     epilog=__doc__.split("\n", 1)[-1],
+                                     )
+    parser.add_argument("--xinclude",
+                        action="store_true",
+                        default=False,
+                        help="Do XInclude processing"
+                        )
+    parser.add_argument("xmlfile",
+                        help="XML file to check well-formedness"
+                        )
+    args = parser.parse_args(args)
+    print(args, file=sys.stderr)
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_cli()
+    result = check_wellformedness(args.xmlfile, args.xinclude)
+    sys.exit(result)

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -28,9 +28,13 @@ def check_wellformedness(xmlfile, xinclude=True):
     # IDs are non-unique:
     xmlparser = etree.XMLParser(collect_ids=False)
     try:
-        xml = etree.parse(xmlfile, parser=xmlparser)
+        tree = etree.parse(xmlfile, parser=xmlparser)
         if xinclude:
-            xml.xinclude()
+            tree.xinclude()
+            # This test is needed to perform XInclude resolution on
+            # second and third levels:
+            if list(tree.iter("{http://www.w3.org/2001/XInclude}include")):
+                tree.xinclude()
         return 0
     except (etree.XMLSyntaxError, etree.XIncludeError) as err:
         print("ERROR: %s" % err, file=sys.stderr)

--- a/make/setfiles.mk
+++ b/make/setfiles.mk
@@ -34,29 +34,13 @@ endif
 
 
 # Check whether the documents are _well-formed_ (not if valid) - if not,
-# exit and display the xmllint error message
-#
+# exit and display the error message
 # Works for both, DocBook4 and DocBook5 since we are only checking for
 # well-formdness and not for validity (a DocBook5 validity check would
 # require jing)
-#
-# If there is a PROFILE URN defined, we do not check for xinclude errors for
-# the following reason
-#
-# If you have a common source for different documents with profiled
-# xi:includes you may want to create branches or tags in you VCS that only
-# contain the source files actually used in a certain document (ignoring the
-# files that will not be included because the xi:include is profiled for
-# a different version).
-# This set of sources is not well-formed. However, after having profiled
-# these documents (which is possible!!!) the resulting profiled sources
-# _are_ well-formed. And DAPS only works on profiled sources...
-#
-ifdef PROFILE_URN
-  CHECK_WELLFORMED := $(shell xmllint --nonet --noout --nowarning --xinclude --loaddtd $(MAIN) 2>&1 | grep -v "XInclude error")
-else
-  CHECK_WELLFORMED := $(shell xmllint --nonet --noout --nowarning --xinclude --loaddtd $(MAIN) 2>&1)
-endif
+
+CHECK_WELLFORMED := $(shell $(LIBEXEC_DIR)/daps-xmlwellformed --xinclude $(MAIN) 2>&1)
+
 ifdef CHECK_WELLFORMED
   $(error Fatal error:$(\n)$(CHECK_WELLFORMED))
 endif

--- a/test/xml-syntax-check/double-ids.xml
+++ b/test/xml-syntax-check/double-ids.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://docbook.org/xml/5.1/rng/docbook.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://docbook.org/xml/5.1/sch/docbook.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<article version="5.1"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Double xml:ids</title>
+ <para>
+  This document contains the same IDs twice. It should be well-formed,
+  but not valid.
+ </para>
+ <procedure xml:id="foo" os="osuse">
+  <title>Procedure for osuse</title>
+  <step><para/></step>
+ </procedure>
+ <procedure xml:id="foo" os="sled;sles">
+  <title>Procedure for SLES and SLED</title>
+  <step><para/></step>
+ </procedure>
+</article>

--- a/test/xml-syntax-check/syntax-error.xml
+++ b/test/xml-syntax-check/syntax-error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<article version="5.1"
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Document with Syntax Error</title>
+ <para>A para with a missing ">" character in the end-tag.</para
+</article>


### PR DESCRIPTION
Related to #425 

This PR contains:

* A Python3 script `daps-xmlwellformed` which parses an XML file and reports any syntax problems.
* The script signals error or success with the usual return code (0=sucess, !=0 error)
* The script contains the option `--xinclude` to switch on/off XInclude handling.


