### PR TITLE
Fix some DocBook identifiers

### DIFF
--- a/configure
+++ b/configure
@@ -3886,12 +3886,12 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: ===== Checking for additional DocBook 4.5 identifiers (optional)..." >&5
 $as_echo "$as_me: ===== Checking for additional DocBook 4.5 identifiers (optional)..." >&6;}
 
-for IDENT in "-//OASIS//ELEMENTS DocBook XML Information Pool V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Character Entities V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Notations V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Additional General Entities V4.5//EN" \
-             "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V4.5//EN" \
-             "-//OASIS//DTD DocBook XML CALS Table Model V4.5//EN" \
+for IDENT in "-//OASIS//ELEMENTS DocBook Information Pool V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Notations V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Additional General Entities V4.5//EN" \
+             "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.5//EN" \
+             "-//OASIS//DTD DocBook CALS Table Model V4.5//EN" \
              "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
              ; do
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $IDENT" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -249,12 +249,12 @@ fi
 dnl --------------------------------------------------------------------------
 AC_MSG_NOTICE([===== Checking for additional DocBook 4.5 identifiers (optional)...])
 
-for IDENT in "-//OASIS//ELEMENTS DocBook XML Information Pool V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Character Entities V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Notations V4.5//EN" \
-             "-//OASIS//ENTITIES DocBook XML Additional General Entities V4.5//EN" \
-             "-//OASIS//ELEMENTS DocBook XML Document Hierarchy V4.5//EN" \
-             "-//OASIS//DTD DocBook XML CALS Table Model V4.5//EN" \
+for IDENT in "-//OASIS//ELEMENTS DocBook Information Pool V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Notations V4.5//EN" \
+             "-//OASIS//ENTITIES DocBook Additional General Entities V4.5//EN" \
+             "-//OASIS//ELEMENTS DocBook Document Hierarchy V4.5//EN" \
+             "-//OASIS//DTD DocBook CALS Table Model V4.5//EN" \
              "-//OASIS//DTD XML Exchange Table Model 19990315//EN" \
              ; do
  AC_MSG_CHECKING([for $IDENT])


### PR DESCRIPTION
The `configure.ac` file had an identifier like this:

    "-//OASIS//ELEMENTS DocBook XML Information Pool V4.5//EN"

However, this is wrong. The official identifier is this (without the XML):

    "-//OASIS//ELEMENTS DocBook Information Pool V4.5//EN"

These applies to some other identifiers which were also fixed in this commit.