### PR TITLE
Make the --docdir option mandatory

### DIFF
--- a/bin/daps-init
+++ b/bin/daps-init
@@ -121,14 +121,8 @@ while true ; do
             shift 2
             ;;
         --docdir|-d)
-            if [[ -z "$2" ]]; then
-                exit_on_error "Please specify a directory"
-            else
-                DOC_DIR="$2"
-                #  strip trailing slash
-                DOC_DIR=${DOC_DIR%/}
-            fi
-            shift 2
+	    DOC_DIR="$2"
+	    shift 2
             ;;
         --docbook4|-4)
             DOCBOOKVERSION=4
@@ -188,6 +182,13 @@ while true ; do
         *) exit_on_error "Wrong parameter: $1" ;;
     esac
 done
+
+if [[ -z "$DOC_DIR" ]]; then
+  exit_on_error "Please specify a directory with --docdir"
+else
+  #  strip trailing slash
+  DOC_DIR=${DOC_DIR%/}
+fi
 
 if [[ -n $PRODUCTNUMBER && -z $PRODUCTNAME ]]; then
     exit_on_error "--productnumber also requires --productname to be specified"


### PR DESCRIPTION
Make the --docdir option mandatory, so that it cannot do foolish things, when the docdir option is not given.
Fixes #434 
Signed-off-by: Fabian Baumanis <fabian.baumanis@suse.com>