### PR TITLE
Fix typo in the unpack-locdrop help section

### DIFF
--- a/lib/daps_functions
+++ b/lib/daps_functions
@@ -2833,7 +2833,7 @@ EOF
 function help_optipng {
     cat <<EOF
     --optipng                 Optimize PNG images by reducing the color
-                              palette (using optipng), Modfies the original
+                              palette (using optipng), Modifies the original
                               sources!
                               Default: off
 EOF


### PR DESCRIPTION
Fix typo in the unpack-locdrop help section.
Signed-off-by: Fabian Baumanis <fabian.baumanis@suse.com>