### PR TITLE
Fix #510: Make XPointer work

### DIFF
--- a/make/validate.mk
+++ b/make/validate.mk
@@ -37,7 +37,10 @@ $(PROFILEDIR)/.validate validate: $(PROFILES)
   ifeq "$(DOCBOOK_VERSION)" "4"
 	xmllint --noent --postvalid --noout --xinclude $(PROFILED_MAIN)
   else
-	$(JING_WRAPPER) $(JING_FLAGS) $(DOCBOOK5_RNG) $(PROFILED_MAIN)
+	@ccecho "info" "Resolving XIncludes and XPointers..."
+	xmllint --output $(PROFILED_MAIN).resolved  --noent --xinclude $(PROFILED_MAIN)
+	@ccecho "info" "Validating with Jing..."
+	$(JING_WRAPPER) $(JING_FLAGS) $(DOCBOOK5_RNG) $(PROFILED_MAIN).resolved
   endif
 	touch $(PROFILEDIR)/.validate
   ifeq "$(TARGET)" "validate"


### PR DESCRIPTION
This PR fixes #510.

Jing fails as it depends on Xerces. As Xerces does not support the `xpointer()` scheme, we need to give jing a "complete" document. The document is created by `xmllint`.

Currently it's an ugly implementation as it appends ".resolved" to the `PROFILED_MAIN` variable. Probably we need to adapt the code in other locations too.

For the time being, it's just fixes the `validate` subcommand.

---

Addition: what's about the following suggestion?

* `daps validate`
    would use the current validation. Nothing changed.
* `daps validate --xpointer`
   would enable the different resolution path with XPointers (resolve them with `xmllint` and validate with `jing`).

