### PR TITLE
Rework daps-xmlwellformed

### DIFF
--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -178,6 +178,10 @@ def get_all_files(xmlfile: str, xinclude: bool):
     except ValueError as err:
         error = err
         rc = ReturnCode.value_err
+    except etree.XSLTApplyError as err:
+        # We search for "Cannot resolve URI <FILENAME>"
+        uri = err.args[0].split("URI ")[-1]
+        problems.append(uri)
     except etree.XIncludeError as error:
         error = err
         rc = ReturnCode.xinclude_err

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -48,37 +48,64 @@ if not os.path.exists(XINCLUDE_XSLT):
 # ------------------------------------------------------------
 # Extension Functions in a SUSE namespace
 
-def exists(context, f) -> bool:
+def exists(context, node) -> bool:
     """Test whether a path exists.  Returns False for
        broken symbolic links
 
-        :param context:
+        :param context: context node
         :param list f: list of path name (however, we
                        are only interested in the first
                        item
         :return: True=Path exists, False otherwise
         :rtype: bool
     """
-    f = f[0]
-    d = context.context_node.getroottree().docinfo.URL
-    d = os.path.dirname(d)
+    f = node[0]
+    d = os.path.dirname(context.context_node.getroottree().docinfo.URL)
     return os.path.exists(os.path.join(d, f))
+
+
+def base(context) -> str:
+    """Returns the base file path from the context node
+
+        :param context: context node
+    """
+    ctxnode = context.context_node
+    return ctxnode.base
 
 
 def abspath(context, f) -> str:
     """Return the absolute path of the context node
 
-        :param context:
+        :param context: context node
         :param list f: list of path name (however, we
                        are only interested in the first
                        item
         :return: absolute path
-        :rtype: str
     """
     f = f[0]
     d = context.context_node.getroottree().docinfo.URL
     d = os.path.dirname(d)
     return os.path.abspath(os.path.join(d, f))
+
+
+def errormsg(context, base: list, href: list) -> str:
+    """Returns a error message string.
+
+        :param context: the context node
+        :param base: the file name where the <xi:include/> element is located
+        :param href: the file name where the <xi:include/> element is pointing to
+        :return: an error message
+    """
+    template = "NOTFOUND:{parent}:{lineno}:0:ERROR:XINCLUDE:NOT_FOUND:{href}"
+    ctxnode = context.context_node
+    d = os.path.dirname(context.context_node.getroottree().docinfo.URL)
+    base = os.path.abspath(os.path.join(d, base[0]))
+    href = href[0]
+
+    return template.format(parent=base,
+                           lineno=ctxnode.sourceline,
+                           href=href
+                           )
 
 
 # ------------------------------------------------------------
@@ -102,7 +129,7 @@ def parse_cli(args=None) -> argparse.Namespace:
                         default=False,
                         help="Do XInclude processing"
                         )
-    parser.add_argument("-X", "--list-files",
+    parser.add_argument("-l", "--list-files",
                         action="store_true",
                         default=False,
                         help="List all XML files which were found"
@@ -155,6 +182,8 @@ def get_all_files(xmlfile: str, xinclude: bool):
     ns = etree.FunctionNamespace(SUSE_NS)
     ns['exists'] = exists
     ns['abspath'] = abspath
+    ns['base'] = base
+    ns['errormsg'] = errormsg
 
     xifiles = []
     notfound = []
@@ -168,8 +197,8 @@ def get_all_files(xmlfile: str, xinclude: bool):
             result = transform(tree)
             for entry in transform.error_log:
                 msg = entry.message
-                if msg.startswith("WARN:"):
-                    _, f = msg.split(":")
+                if msg.startswith("NOTFOUND:"):
+                    _, f = msg.split(":", 1)
                     notfound.append(f)
                 else:
                     problems.append(str(entry))
@@ -177,21 +206,24 @@ def get_all_files(xmlfile: str, xinclude: bool):
 
     except ValueError as err:
         error = err
-        rc = ReturnCode.value_err
+        rc = 10
     except etree.XSLTApplyError as err:
         # We search for "Cannot resolve URI <FILENAME>"
         uri = err.args[0].split("URI ")[-1]
         problems.append(uri)
-    except etree.XIncludeError as error:
+    except etree.XIncludeError as err:
         error = err
-        rc = ReturnCode.xinclude_err
+        rc = 20
     except etree.XMLSyntaxError as err:
         error = err
-        rc = ReturnCode.syntax_error
+        rc = 30
+    except OSError as err:
+        error = err
+        rc = 40
 
     if error:
         print(error, file=sys.stderr)
-        sys.exit(rc.value)
+        sys.exit(rc)
 
     return xifiles, notfound, problems
 

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -36,8 +36,8 @@ NOTFOUND=[]
 PROBLEMS=[]
 
 
-if etree.LXML_VERSION < (4, 2, 1):
-    print("ERROR: Need minimum version 4.2.1 of lxml.",
+if etree.LXML_VERSION < (3, 4, 0):
+    print("ERROR: Need minimum version 3.4.0 of lxml.",
           file=sys.stderr)
     sys.exit(10)
 

--- a/libexec/daps-xmlwellformed
+++ b/libexec/daps-xmlwellformed
@@ -12,26 +12,32 @@
 """
 
 __author__ = "Thomas Schraitle"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 import argparse
 import os
-import re
 import sys
-import textwrap
-import warnings
 
 from lxml import etree
 
+# -- Constants
 HERE = os.path.dirname(os.path.realpath(__file__))
 BASE = os.path.basename(__file__)
 XINCLUDE_XSLT = os.path.join(HERE, "%s-xinclude.xsl" % BASE)
 SUSE_NS = "urn:x-suse:ns:python"
-ENTITY_NOT_FOUND = re.compile(r'Entity\s+(.*)\s+not defined')
+
+# -- Useful global variables
+XMLPARSER = etree.XMLParser(collect_ids=False)
+XSLT = etree.parse(XINCLUDE_XSLT)
+
+# Some global variables to store the result
+XMLFILES=[]
+NOTFOUND=[]
+PROBLEMS=[]
 
 
-if etree.LXML_VERSION < (3, 4, 0):
-    print("ERROR: I need a minimum version of 3.4.0 of lxml.",
+if etree.LXML_VERSION < (4, 2, 1):
+    print("ERROR: Need minimum version 4.2.1 of lxml.",
           file=sys.stderr)
     sys.exit(10)
 
@@ -77,98 +83,6 @@ def abspath(context, f) -> str:
 
 # ------------------------------------------------------------
 #
-
-def process_xinclude(tree) -> list:
-    """Process the tree with a XSLT stylesheet which
-       resolves any XIncludes. Prints
-
-    :param tree: the ElementTree
-    """
-    # This notation is needed for lxml <v4:
-    ns = etree.FunctionNamespace(SUSE_NS)
-    ns['exists'] = exists
-    ns['abspath'] = abspath
-
-    # tree.xinclude()
-    # HACK for lxml < v4.2.1:
-    # This test is needed to perform XInclude resolution on
-    # second and third levels:
-    # if list(tree.iter("{http://www.w3.org/2001/XInclude}include")):
-    #    tree.xinclude()
-
-    # Let's use XSLT to handle XIncludes manually; this is needed
-    # for two reasons:
-    # 1. lxml seems to have a bug when resolving XIncludes on the
-    #    second level
-    # 2. we need to handle cases where the file cannot be found
-    xitransform = etree.XSLT(etree.parse(XINCLUDE_XSLT))
-    problems = []
-    try:
-        result = xitransform(tree)
-        for entry in xitransform.error_log:
-            msg = entry.message
-            if msg.startswith("INFO"):
-                continue
-
-            # If there is an unresolved/undefined entity,
-            # warn about it:
-            if ENTITY_NOT_FOUND.match(msg):
-                problems.append(msg)
-                warnings.warn_explicit(msg,
-                                       category=Warning,
-                                       filename=entry.filename,
-                                       lineno=entry.line,
-                                       )
-            # Anything related to unresolved <xi:include/> elements:
-            if msg.startswith("WARN"):
-                problems.append(msg)
-                warnings.warn_explicit(msg[6:],
-                                       category=Warning,
-                                       filename=entry.filename,
-                                       lineno=entry.line,
-                                       )
-
-    except etree.XSLTApplyError as err:
-        # We search for "Cannot resolve URI <FILENAME>"
-        uri = err.args[0].split("URI ")[-1]
-        problems.append(uri)
-
-    return problems
-
-
-def check_wellformedness(xmlfile,
-                         warnings_as_errors=False,
-                         xinclude=True) -> int:
-    """Checks a file for well-formedness
-
-    This only works with lxml >= 3.4.0 (because of collect_ids option)
-
-    :param str xmlfile: filename to XML file
-    :param bool xinclude: do xinclude processing (default: True) or not
-    :return: 0 (everything ok) or != 0 (some problem)
-    :rtype: int
-    """
-    # We don't want to collect all IDs to avoid problems when
-    # IDs are non-unique:
-    xmlparser = etree.XMLParser(collect_ids=False)
-    try:
-        tree = etree.parse(xmlfile, parser=xmlparser)
-        if xinclude:
-            r = process_xinclude(tree)
-            if r and warnings_as_errors:
-                raise ValueError()
-        return 0
-
-    except ValueError as err:
-        # print("ERROR", file=sys.stderr)
-        return 20
-
-    except (etree.XMLSyntaxError, etree.XIncludeError) as err:
-        print("ERROR: %s" % err, file=sys.stderr)
-        print(textwrap.indent(str(err.error_log), prefix="       "), file=sys.stderr)
-        return 10
-
-
 def parse_cli(args=None) -> argparse.Namespace:
     """Parse CLI arguments
 
@@ -187,6 +101,11 @@ def parse_cli(args=None) -> argparse.Namespace:
                         action="store_true",
                         default=False,
                         help="Do XInclude processing"
+                        )
+    parser.add_argument("-X", "--list-files",
+                        action="store_true",
+                        default=False,
+                        help="List all XML files which were found"
                         )
     parser.add_argument("-W", "--warnings-as-errors",
                         action="store_true",
@@ -212,23 +131,108 @@ def parse_cli(args=None) -> argparse.Namespace:
     return args
 
 
-if __name__ == "__main__":
+def unique(lst: list):
+    """Makes a list unique (preserves order)
+
+    :param lst: the list that needs to be unique
+    :return: the (maybe) reduced list with unique elements
+    """
+    seen = {}
+
+    for item in lst:
+        if item in seen: continue
+        seen[item] = 1
+        yield item
+
+
+def get_all_files(xmlfile: str, xinclude: bool):
+    """Returns a list of all files when enabling XInclude processing
+
+    :param xmlfile: filename of XML file
+    :param xinclude: Enable or disable XInclude processing
+    :return:
+    """
+    ns = etree.FunctionNamespace(SUSE_NS)
+    ns['exists'] = exists
+    ns['abspath'] = abspath
+
+    xifiles = []
+    notfound = []
+    problems = []
+    error = None
+
+    try:
+        tree = etree.parse(xmlfile, parser=XMLPARSER)
+        transform = etree.XSLT(XSLT)
+        if xinclude:
+            result = transform(tree)
+            for entry in transform.error_log:
+                msg = entry.message
+                if msg.startswith("WARN:"):
+                    _, f = msg.split(":")
+                    notfound.append(f)
+                else:
+                    problems.append(str(entry))
+            xifiles = str(result).rstrip().split("\n")
+
+    except ValueError as err:
+        error = err
+        rc = ReturnCode.value_err
+    except etree.XIncludeError as error:
+        error = err
+        rc = ReturnCode.xinclude_err
+    except etree.XMLSyntaxError as err:
+        error = err
+        rc = ReturnCode.syntax_error
+
+    if error:
+        print(error, file=sys.stderr)
+        sys.exit(rc.value)
+
+    return xifiles, notfound, problems
+
+
+def main() -> int:
+    """Main function
+
+    :return: error code
+    """
+    failures, successes = (0, 0)
+
     args = parse_cli()
-    endresult=0
-    failures=0
-    successes=0
+
     for xmlfile in args.xmlfiles:
-        result = check_wellformedness(xmlfile,
-                                  args.warnings_as_errors,
-                                  args.xinclude)
-        if result:
-            failures += 1
-        else:
-            successes += 1
-        endresult += result
+        xifiles, notfound, problems = get_all_files(xmlfile, args.xinclude)
+        XMLFILES.extend(xifiles)
+        NOTFOUND.extend(notfound)
+        PROBLEMS.extend(problems)
+        successes += len(xifiles)
+        failures += len(notfound)
+
+    if args.list_files:
+        print("---- XML Files ----", file=sys.stderr)
+        for f in unique(XMLFILES):
+            print(f, file=sys.stderr)
+        print()
+
+    if PROBLEMS:
+        print("---- XML Problems ---", file=sys.stderr)
+        for p in PROBLEMS:
+            print(p, file=sys.stderr)
+        print()
+
+    if NOTFOUND:
+        print("--- Missing Files ---", file=sys.stderr)
+        for f in NOTFOUND:
+            print(f, file=sys.stderr)
+        print()
+
     if args.stats:
-        msg = ("--- Successful Files={successes}, "
-               "Failed files={failures} ---").format(**locals())
+        msg = ("--- Successful Files={s}, "
+               "Failed files={f} ---").format(s=successes, f=failures)
         print(msg, file=sys.stderr)
 
-    sys.exit(endresult)
+    return 1 if bool(PROBLEMS or NOTFOUND) else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/daps-xmlwellformed-xinclude.xsl
+++ b/libexec/daps-xmlwellformed-xinclude.xsl
@@ -33,11 +33,13 @@
   <xsl:variable name="abspath" select="s:abspath(@href)"/>
   <xsl:choose>
    <xsl:when test="s:exists(@href)">
-    <xsl:message>INFO: XIncluding <xsl:value-of select="$abspath"/></xsl:message>
+    <xsl:text>FILE:</xsl:text>
+    <xsl:value-of select="$abspath"/>
+    <xsl:text>&#10;</xsl:text>
     <xsl:apply-templates select="document($abspath, .)"/>
    </xsl:when>
    <xsl:otherwise>
-    <xsl:message>WARN: File not found "<xsl:value-of select="@href"/>"</xsl:message>
+    <xsl:message>WARN:File not found "<xsl:value-of select="@href"/>"</xsl:message>
    </xsl:otherwise>
   </xsl:choose>
  </xsl:template>

--- a/libexec/daps-xmlwellformed-xinclude.xsl
+++ b/libexec/daps-xmlwellformed-xinclude.xsl
@@ -29,17 +29,33 @@
  <xsl:output method="text"/>
  <xsl:template match="text()"/>
 
+ <xsl:template match="*" mode="included">
+  <xsl:param name="base"/>
+  <xsl:copy>
+   <xsl:copy-of select="@*"/>
+   <xsl:attribute name="xml:base">
+    <xsl:value-of select="$base"/>
+   </xsl:attribute>
+   <xsl:apply-templates>
+    <xsl:with-param name="base" select="$base"/>
+   </xsl:apply-templates>
+  </xsl:copy>
+ </xsl:template>
+
  <xsl:template match="xi:include">
+  <xsl:param name="base" select="s:base()"/>
   <xsl:variable name="abspath" select="s:abspath(@href)"/>
   <xsl:choose>
    <xsl:when test="s:exists(@href)">
     <xsl:text>FILE:</xsl:text>
     <xsl:value-of select="$abspath"/>
     <xsl:text>&#10;</xsl:text>
-    <xsl:apply-templates select="document($abspath, .)"/>
+    <xsl:apply-templates select="document($abspath, .)" mode="included">
+      <xsl:with-param name="base" select="@href"/>
+    </xsl:apply-templates>
    </xsl:when>
    <xsl:otherwise>
-    <xsl:message>WARN:File not found "<xsl:value-of select="@href"/>"</xsl:message>
+    <xsl:message><xsl:value-of select="s:errormsg($base, @href)"/></xsl:message>
    </xsl:otherwise>
   </xsl:choose>
  </xsl:template>


### PR DESCRIPTION
This PR contains a reworked version of `daps-xmlwellformed`:

The script uses a different strategy now. It collect XML filenames, XML problems, and missing files.

* Print XML filename as `FILE:<NAME>` on stdout (XSLT stylesheet)
* Request lxml version 4.2.1 as minimum (although it might work for others too)
* Introduce new option `-X`/`--list-files` to output all included files
* Output a unique list of files from all given XML files on the command line
* Introduce `unique(lst)` function (preserves order)
* Remove unnecessary imports and variables

To amuse Stefan, here is a short `time` output:

```
real    0m1,537s
user    0m1,318s
sys     0m0,219s
```

Actually it wasn't really needed to collect a list of all XML files. The way how it was included *was* already a XML well-formed test. :wink: 