### PR TITLE
Fix creation of $SPACE with GNU Make 4.3

### DIFF
--- a/make/common_variables.mk
+++ b/make/common_variables.mk
@@ -46,8 +46,8 @@ endif
 # a space is needed, since it is not possible to replace a literal
 # space (same goes for comma)
 #
-SPACE :=
-SPACE +=
+empty :=
+SPACE := $(empty) $(empty)
 
 COMMA := ,
 


### PR DESCRIPTION
GNU Make 4.3 has this incompatible change:
  * WARNING: Backward-incompatibility!
    Previously appending using '+=' to an empty variable would result in a
    value starting with a space
This is eactly what the code relied on to before.

https://bugzilla.opensuse.org/show_bug.cgi?id=1168051