### PR TITLE
Transform DocBook5 into an intermediate document (for Pandoc)

### DIFF
--- a/daps-xslt/pandoc/db2db.xsl
+++ b/daps-xslt/pandoc/db2db.xsl
@@ -20,7 +20,7 @@
    Output:
      DocBook5 document with the following changes:
 
-     * procedure or substeps -> itemizedlist
+     * procedure or substeps -> orderedlist
      * steps -> listitem
 
    See Also:
@@ -39,9 +39,9 @@
    <xsl:import href="../common/copy.xsl"/>
 
    <xsl:template match="d:procedure|d:substeps">
-      <itemizedlist>
+      <orderedlist>
          <xsl:apply-templates select="@*|node()"/>
-      </itemizedlist>
+      </orderedlist>
    </xsl:template>
 
    <xsl:template match="d:step">

--- a/daps-xslt/pandoc/db2db.xsl
+++ b/daps-xslt/pandoc/db2db.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Purpose:
+     Transform a DocBook5 document into an intermediate DocBook5
+     document ready for consumption by pandoc.
+
+   Usage:
+     $ xsltproc db2db.xsl XMLFILE | pandoc -f docbook -t rst \
+       -o /tmp/XMLFILENAME.rst -
+
+     (Don't forget the dash in the previous line.)
+
+   Parameters:
+     None
+
+   Input:
+     DocBook5 document
+
+   Output:
+     DocBook5 document with the following changes:
+
+     * procedure or substeps -> itemizedlist
+     * steps -> listitem
+
+   See Also:
+     man pandoc
+
+   Author:    Thomas Schraitle <toms@opensuse.org>
+   Copyright (C) 2020 SUSE Software Solutions Germany GmbH
+
+-->
+
+<xsl:stylesheet version="1.0"
+   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns:d="http://docbook.org/ns/docbook"
+   xmlns="http://docbook.org/ns/docbook">
+
+   <xsl:import href="../common/copy.xsl"/>
+
+   <xsl:template match="d:procedure|d:substeps">
+      <itemizedlist>
+         <xsl:apply-templates select="@*|node()"/>
+      </itemizedlist>
+   </xsl:template>
+
+   <xsl:template match="d:step">
+      <listitem>
+         <xsl:apply-templates select="@*|node()"/>
+      </listitem>
+   </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This stylesheet can be used to create an intermediate file for Pandoc. As Pandoc has some issues, the intermediate file is used to simplify the conversion to RST.

DocBook5 document with the following changes:
* procedure or substeps -> ~itemizedlist~ orderedlist
* steps -> listitem

Use it like:

```
xsltproc db2db.xsl XMLFILE | pandoc -f docbook -t rst  -o /tmp/XMLFILENAME.rst -
```