### PR TITLE
Remove stale links from GH issue or SF

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,8 +27,7 @@ The https://github.com/openSUSE/daps/releases/latest[latest DAPS version].
 
 == Forum
 
-Look into https://github.com/openSUSE/daps/discussions[GitHub Discussions]
-to find or create new posts.
+Use the https://github.com/openSUSE/daps/discussions[GitHub Discussions] of this repository.
 
 
 == Reporting Bugs

--- a/README.adoc
+++ b/README.adoc
@@ -27,12 +27,8 @@ The https://github.com/openSUSE/daps/releases/latest[latest DAPS version].
 
 == Forum
 
-For discussions, the bug tracker of this repo has a __forum__ label.
-
-Use this label to:
-
-* Find posts: https://github.com/openSUSE/daps/issues?q=is%3Aissue+label%3Aforum
-* Create a new post: https://github.com/openSUSE/daps/issues/new?labels=forum&template=forum.md
+Look into https://github.com/openSUSE/daps/discussions[GitHub Discussions]
+to find or create new posts.
 
 
 == Reporting Bugs

--- a/doc/adoc/daps_asciidoc.adoc
+++ b/doc/adoc/daps_asciidoc.adoc
@@ -397,7 +397,7 @@ Find links to useful online resources here.
 
 * https://opensuse.github.io/daps/doc/book.daps.user.html[User Guide]
 * https://opensuse.github.io/daps/[Project Page]
-* https://sourceforge.net/p/daps/discussion/General/[Discussion]
+* https://github.com/openSUSE/daps/discussions[Discussion]
 
 === {adoc}
 

--- a/doc/xml/phrases-decl.ent
+++ b/doc/xml/phrases-decl.ent
@@ -36,10 +36,10 @@
    this guide and the other documentation included with &dapsacr;). You can
    contact us on the <literal>#opensuse-doc</literal> IRC channel on
    <literal>irc.freenode.net</literal> or in the discussion forum at <ulink
-   url="http://sourceforge.net/p/daps/discussion/"></ulink>.
+   url="https://github.com/openSUSE/daps/discussions"/>.
    For bugs or enhancement requests, open an issue at
-   <ulink url="https://github.com/openSUSE/daps/issues/new"></ulink>. A user account
-   at <ulink url="https://github.com"></ulink> is needed.</para>
+   <ulink url="https://github.com/openSUSE/daps/issues/new"/>. A user account
+   at <ulink url="https://github.com"/> is needed.</para>
    <para>
    Patches and user contributions are welcome!
   </para>

--- a/packaging/debian/TODO.Debian
+++ b/packaging/debian/TODO.Debian
@@ -10,4 +10,4 @@ You can add more wishes for the Ubuntu package there:
 https://blueprints.launchpad.net/daps
 
 Wishes to the upstream developers you can add there:
-https://sourceforge.net/p/daps/tickets/?source=navbar
+https://github.com/openSUSE/daps/issues

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -33,7 +33,7 @@ Build-Depends: debhelper (>= 8.0.0),
                w3m,
                xsltproc
 Standards-Version: 3.9.5
-Homepage: http://sourceforge.net/projects/daps
+Homepage: https://github.com/openSUSE/daps
 Vcs-Bzr: lp:daps
 Vcs-Browser: http://bazaar.launchpad.net/~sascha-manns-h/daps/trunk/files
 
@@ -70,7 +70,7 @@ Depends: ${shlibs:Depends},
          w3m,
          xsltproc
 Recommends: aspell,
-         aspell-en,         
+         aspell-en,
          epubcheck,
          jing,
          optipng,

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: daps
-Source: http://sourceforge.net/projects/daps
+Source: https://github.com/openSUSE/daps
 
 Files: *
 Copyright: 2011-2014 openSUSE Doc-Team


### PR DESCRIPTION
Remove old links to SourceForge and GH issues with the forum label and replace it with link to GH Discussions.