### PR TITLE
Remove python-xml from spec file

### DIFF
--- a/doc/xml/phrases-decl.ent
+++ b/doc/xml/phrases-decl.ent
@@ -166,7 +166,7 @@
      </step>
      <step>
       <para>Add the &suse-dapsrepo; repository with the following zypper command:</para>
-      <screen>&prompt.root;<command>zypper addrepo --refresh obs://Documentation:Tool &suse-dapsrepo;</command></screen>
+      <screen>&prompt.root;<command>zypper addrepo --refresh obs://Documentation:Tools &suse-dapsrepo;</command></screen>
      </step>
      <step>
       <para>Install &dapsacr; with the following zypper command:</para>

--- a/doc/xml/phrases-decl.ent
+++ b/doc/xml/phrases-decl.ent
@@ -166,7 +166,7 @@
      </step>
      <step>
       <para>Add the &suse-dapsrepo; repository with the following zypper command:</para>
-      <screen>&prompt.root;<command>zypper addrepo --refresh obs://Documentation:Tools &suse-dapsrepo;</command></screen>
+      <screen>&prompt.root;<command>zypper addrepo --refresh obs://&suse-dapsrepo; &suse-dapsrepo;</command></screen>
      </step>
      <step>
       <para>Install &dapsacr; with the following zypper command:</para>

--- a/doc/xml/phrases-decl.ent
+++ b/doc/xml/phrases-decl.ent
@@ -162,26 +162,15 @@
     <procedure>
      <title>Installing &dapsacr; via Zypper From &suse-dapsrepo;</title>
      <step>
-      <para>Open a browser and enter the following URL: <ulink url="http://download.opensuse.org/repositories/Documentation:/Tools"></ulink></para>
-     </step>
-     <step>
-      <para>Select your distribution and product number to make the browser show the URL for the respective repository.</para>
-     </step>
-     <step>
-      <para>Copy the URL from the address bar.</para>
-     </step>
-     <step>
       <para>Open a terminal.</para>
      </step>
      <step>
-      <para>Add the repository with the following zypper command:</para>
-      <screen>&prompt.root;<command>zypper ar -f <replaceable>URL</replaceable> &suse-dapsrepo;</command></screen>
-      <para>Replace <replaceable>URL</replaceable> with the URL you pasted from
-      your browser.</para>
+      <para>Add the &suse-dapsrepo; repository with the following zypper command:</para>
+      <screen>&prompt.root;<command>zypper addrepo --refresh obs://Documentation:Tool &suse-dapsrepo;</command></screen>
      </step>
      <step>
       <para>Install &dapsacr; with the following zypper command:</para>
-      <screen>&prompt.root;<command>zypper in --from &suse-dapsrepo; daps</command></screen>
+      <screen>&prompt.root;<command>zypper install --from &suse-dapsrepo; daps</command></screen>
       <para>In order to install &dapsacr; you have to trust the <systemitem>&suse-dapsrepo;</systemitem> repository.</para>
      </step>
     </procedure>

--- a/packaging/daps.spec
+++ b/packaging/daps.spec
@@ -66,7 +66,6 @@ BuildRequires:  libxml2-tools
 BuildRequires:  libxslt
 BuildRequires:  libxslt-tools
 BuildRequires:  poppler-tools
-BuildRequires:  python-xml
 BuildRequires:  python3-lxml
 BuildRequires:  suse-xsl-stylesheets
 BuildRequires:  svg-dtd
@@ -111,7 +110,6 @@ Requires:       jing
 Requires:       libxslt
 Requires:       make
 Requires:       poppler-tools
-Requires:       python-xml
 Requires:       python3-lxml
 Requires:       suse-xsl-stylesheets
 Requires:       svg-schema


### PR DESCRIPTION
This PR contains:

* Remove obsolete python-xml.
  This package is for Python2. However, the same functionality is available through `python3-base`.

See #584 for a correct PR.