### PR TITLE
DC file parser fix

### DIFF
--- a/bin/daps.in
+++ b/bin/daps.in
@@ -912,7 +912,7 @@ function set_mainfile {
 # Recover command-line values
 #
 function recover_cmdl_values {
-    # adoc attributes is special becauzse it can be specified multiple times
+    # adoc attributes is special because it can be specified multiple times
     # we want to keep all values
     test -n "$ADOC_ATTRIBUTES_CMDL" && ADOC_ATTRIBUTES="$ADOC_ATTRIBUTES $ADOC_ATTRIBUTES_CMDL"
     test -n "$ADOC_SET_CMDL"  && ADOC_SET="$ADOC_SET_CMDL"
@@ -1005,6 +1005,9 @@ function parse_config {
         elif [[ "$KEY" =~ \+$ ]]; then
             CONCAT=1
             KEY="${KEY%*+}"           # del trailing "+"
+        else
+            # Do not concatenate values that have no +=, overwrite them
+            CONCAT=0
         fi
 
         # check if KEY is a valid variable name
@@ -1175,8 +1178,8 @@ while true ; do
             shift 2
             ;;
         --schema)
-            DOCBOOK5_RNG_URI="$2"
-            DOCBOOK5_RNG_URI_CMDL="$DOCBOOK5_RNG_URI"
+            DOCBOOK5_RNG_URI_CMDL="$2"
+            DOCBOOK5_RNG_URI="$DOCBOOK5_RNG_URI_CMDL"
             shift 2
             ;;
         --styleroot)

--- a/bin/daps.in
+++ b/bin/daps.in
@@ -948,6 +948,8 @@ function parse_config {
     OLD_IFS="$IFS"
     shopt -s extglob
     while IFS='= ' read KEY VALUE; do
+        # no cocatenation by default
+        CONCAT=0
         let LINE_NO++
         # skip empty lines
         [[ -z "$KEY" ]] && continue
@@ -1005,9 +1007,6 @@ function parse_config {
         elif [[ "$KEY" =~ \+$ ]]; then
             CONCAT=1
             KEY="${KEY%*+}"           # del trailing "+"
-        else
-            # Do not concatenate values that have no +=, overwrite them
-            CONCAT=0
         fi
 
         # check if KEY is a valid variable name


### PR DESCRIPTION
When providing KEY=Value and KEY was already set by a config file.
Value was concatenated to the existing value rather than overwriting
the existing value

Toms, Stefan, could you polease test this? I stmbled upon this error when building SBPs who have the `DOCBOOK_RNG_URI` parameter set in the DC file and me having the same parameter set in `~/.config/daps/dapsrc`. This resulted in a fatal error, because in the end `DOCBOOK_RNG_URI` ciontained both values.

This fix, however, changes the behaviour globally for every value that is parsed in all confiig files. It does the right thing, but maybe we relied on the old behaviour for some parameters... .