### PR TITLE
Fixes giving same XSLT param as param and stringparam causes fail

### DIFF
--- a/libexec/daps-xslt
+++ b/libexec/daps-xslt
@@ -298,9 +298,25 @@ while true; do
             OUTPUT="-o $2"
             shift 2;;
         --param)
+            # Ugly Hack warning:
+            # xsltproc does not care if you specify a "param" as "stringparam"
+            # (only vice versa) that means if you secify --param foo=1 and
+            # --stringparam "foo=1" xsltproc will exit with an error, because
+            # "foo" has been declared two times.
+            # Changing process_params to correct this properly (keeping param
+            # and stringparam) would be a major effort, so we are assuming
+            # everything was passed as --stringparam by only writing to
+            # STRPARMS. This fixes issue #589
+            # NOTE that there is a bug (not sure why, AFAIK this should not
+            # happen, since getopt is supposed to specifiy parameters in
+            # correct order):
+            # if you specify multiple values of the same parameter on the
+            # command line there is no way to tell which one will win
+            #
             # Test for equal sign
             if [[ $2 =~ = ]]; then
-                PARMS+=("\"$2\"")
+                STRPARMS+=("\"$2\"")
+                #PARMS+=("\"$2\"")
             else
                 exit_on_error "--param requires \"KEY=VALUE\" as parameter"
             fi
@@ -384,12 +400,16 @@ fi
 #
 if [[ $PROCESSOR =~ xsltproc ]]; then
     # Process stringparam and param values for xsltproc
+    #
+    # see ugly hack warning above
+    #
     if [[ -n "${STRPARMS[@]}" ]]; then
         PARAMETERS=("$(process_params "stringparam" "${STRPARMS[@]}")") || exit_on_error "wrong parameter for function process_params, must be either \"param\" or \"stringparam\""
     fi
-    if [[ -n "${PARMS[@]}" ]]; then
-        PARAMETERS+=("$(process_params "param" "${PARMS[@]}")") || exit_on_error "wrong parameter  for function process_params, must be either \"param\" or \"stringparam\""
-    fi
+    # commented as part of ugly hack
+    #if [[ -n "${PARMS[@]}" ]]; then
+    #    PARAMETERS+=("$(process_params "param" "${PARMS[@]}")") || exit_on_error "wrong parameter  for function process_params, must be either \"param\" or \"stringparam\""
+    #fi
 
     COMMAND="$XSLTPROC $XSLTPROC_ARGS $XINCLUDE ${PARAMETERS[*]} $OUTPUT $STYLESHEET $XMLFILE"
 


### PR DESCRIPTION
Fixes #589

Ugly Hack warning:
xsltproc does not care if you specify a "param" as "stringparam"
(only vice versa) that means if you secify --param foo=1 and
--stringparam "foo=1" xsltproc will exit with an error, because
"foo" has been declared two times.
Changing process_params to correct this properly (keeping param
and stringparam) would be a major effort, so we are assuming
everything was passed as --stringparam by only writing to
STRPARMS. This fixes issue #589
NOTE that there is a bug (not sure why, AFAIK this should not
happen, since getopt is supposed to specifiy parameters in
correct order):
if you specify multiple values of the same parameter on the
command line there is no way to tell which one will win