### PR TITLE
Add stylesheet to convert tables into variablelists

### DIFF
--- a/daps-xslt/contrib/convert-table2variablelist.xsl
+++ b/daps-xslt/contrib/convert-table2variablelist.xsl
@@ -70,15 +70,15 @@
 
   <xsl:template match="d:entry[1]">
     <term>
-      <xsl:apply-templates select="d:para[1]/*"/>
+      <xsl:apply-templates select="d:para[1]/node()"/>
     </term>
     <xsl:text>&#10;</xsl:text>
   </xsl:template>
 
   <xsl:template match="d:entry[2]">
     <listitem>
-      <xsl:copy-of select="*"/>
-      <xsl:copy-of select="../d:entry[position()>=3]/*"/>
+      <xsl:copy-of select="node()"/>
+      <xsl:copy-of select="../d:entry[position()>=3]/node()"/>
     </listitem>
     <xsl:text>&#10;</xsl:text>
   </xsl:template>

--- a/daps-xslt/contrib/convert-table2variablelist.xsl
+++ b/daps-xslt/contrib/convert-table2variablelist.xsl
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Purpose:
+     Converts a informaltable or table into a variablelist.
+
+   Parameters:
+     * None
+
+   Input:
+     DocBook 5 document
+
+   Output:
+     DocBook 5 document with variablelist.
+
+   Design:
+     Any elements inside entry/para are copied to a listitem. It is
+     assumed, that both content models are the same.
+
+   HINTS:
+     * If you want to keep entities, you need to protect them before the
+       transformation, for example: &foo; -> [[foo]]
+       See libexec/entities-exchange.sh
+     * As with almost every XSLT transformation, whitespace can be an issue.
+       Either it isn't preserved or additional whitespace can be introduced.
+
+   Author:    Tom Schraitle <toms@opensuse.org>
+   Copyright (C) 2021 SUSE Software Solutions Germany GmbH
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  exclude-result-prefixes="d">
+
+  <xsl:strip-space elements="d:*"/>
+  <xsl:output indent="yes"/>
+
+  <!-- Identity transformation, all nodes are copied -->
+  <xsl:template match="node() | @*">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Ignore these elements -->
+  <xsl:template match="d:tgroup/d:thead"/>
+  <xsl:template match="d:colspec"/>
+  <xsl:template match="d:entry[3]"/>
+
+  <!-- The template rules -->
+  <xsl:template match="d:informaltable|d:table">
+    <variablelist>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates/>
+    </variablelist>
+  </xsl:template>
+
+  <xsl:template match="d:tgroup | d:tbody | d:thead">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="d:row">
+    <varlistentry>
+      <xsl:apply-templates/>
+    </varlistentry>
+  </xsl:template>
+
+  <xsl:template match="d:entry[1]">
+    <term>
+      <xsl:apply-templates select="d:para[1]/*"/>
+    </term>
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="d:entry[2]">
+    <listitem>
+      <xsl:copy-of select="*"/>
+      <xsl:copy-of select="../d:entry[position()>=3]/*"/>
+    </listitem>
+    <xsl:text>&#10;</xsl:text>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Any `<informaltable>` or `<table>` is converted into a `<variablelist>`.

It is done so with these rules:
* the first column's `entry/para/*` content forms the `<term>`
* the second and consecutive columns are copied into the `<listitem>`

Needed by Carla.

----

<details><summary>Details (click me)</summary>
<p>

Use the following command to transform it:

```shell
$ xsltproc convert-table2variablelist.xsl informaltable.xml
```

Tested with the following example (save it as `informaltable.xml`):

```xml
<informaltable xmlns="http://docbook.org/ns/docbook" version="5.1" xml:lang="en" xml:id="foofoo">
  <tgroup cols="3">
    <colspec colwidth="1*"/>
    <colspec colwidth="3*"/>
    <colspec colwidth="2*"/>
    <thead>
      <row>
        <entry>
          <para> Attribute </para>
        </entry>
        <entry>
          <para> Values </para>
        </entry>
        <entry>
          <para> Description </para>
        </entry>
      </row>
    </thead>
    <tbody>
      <row>
        <entry>
          <para>
            <literal>path</literal>
          </para>
        </entry>
        <entry>
          <para> Mount point for the subvolume. </para>
          <screen>&lt;path&gt;tmp&lt;/tmp&gt;</screen>
        </entry>
        <entry>
          <para> Required. AutoYaST will ignore the subvolume if the
              <literal>path</literal> is not specified. </para>
        </entry>
      </row>
      <row>
        <entry>
          <para>
            <literal>copy-on-write</literal>
          </para>
        </entry>
        <entry>
          <para> Whether copy-on-write should be enabled for the subvolume. </para>
          <screen>&lt;copy-on-write config:type="boolean"&gt;false&lt;/copy-on-write&gt;</screen>
        </entry>
        <entry>
          <para> Optional. The default value is <literal>false</literal>.
          </para>
        </entry>
      </row>
      <row>
        <entry>
          <para>
            <literal>referenced_limit</literal>
          </para>
        </entry>
        <entry>
          <para> Set a quota for the subvolume. </para>
          <screen>&lt;referenced_limit&gt;1 GiB&lt;/referenced_limit&gt;</screen>
        </entry>
        <entry>
          <para> Optional. The default value is <literal>unlimited</literal>.
            Btrfs supports two kinds of limits: <literal>referenced</literal>
            and <literal>exclusive</literal>. At this point, only the former is
            supported. </para>
        </entry>
      </row>
    </tbody>
  </tgroup>
</informaltable>
```

</p>
</details>
