### PR TITLE
Fix typos in XML catalogs

### DIFF
--- a/etc/catalog.debian
+++ b/etc/catalog.debian
@@ -31,7 +31,7 @@
             uri="profiling/docbook42-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook42-profile.xsl"
             uri="profiling/docbook42-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook42-profile.xsl"
             uri="profiling/docbook42-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook43-profile.xsl"
@@ -40,7 +40,7 @@
             uri="profiling/docbook43-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook43-profile.xsl"
             uri="profiling/docbook43-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook43-profile.xsl"
             uri="profiling/docbook43-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook44-profile.xsl"
@@ -49,7 +49,7 @@
             uri="profiling/docbook44-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook44-profile.xsl"
             uri="profiling/docbook44-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook44-profile.xsl"
             uri="profiling/docbook44-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook45-profile.xsl"
@@ -58,7 +58,7 @@
             uri="profiling/docbook45-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
             uri="profiling/docbook45-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
             uri="profiling/docbook45-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
@@ -67,7 +67,7 @@
             uri="profiling/docbook50-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook50-profile.xsl"
             uri="profiling/docbook50-profile.xsl" />
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook50-profile.xsl"
             uri="profiling/docbook50-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
@@ -76,7 +76,7 @@
             uri="profiling/docbook51-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook51-profile.xsl"
             uri="profiling/docbook51-profile.xsl" />
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook51-profile.xsl"
             uri="profiling/docbook51-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:novdoc-profile.xsl"

--- a/etc/catalog.generic
+++ b/etc/catalog.generic
@@ -31,7 +31,7 @@
             uri="profiling/docbook42-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook42-profile.xsl"
             uri="profiling/docbook42-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook42-profile.xsl"
             uri="profiling/docbook42-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook43-profile.xsl"
@@ -40,7 +40,7 @@
             uri="profiling/docbook43-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook43-profile.xsl"
             uri="profiling/docbook43-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook43-profile.xsl"
             uri="profiling/docbook43-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook44-profile.xsl"
@@ -49,7 +49,7 @@
             uri="profiling/docbook44-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook44-profile.xsl"
             uri="profiling/docbook44-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook44-profile.xsl"
             uri="profiling/docbook44-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook45-profile.xsl"
@@ -58,7 +58,7 @@
             uri="profiling/docbook45-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
             uri="profiling/docbook45-profile.xsl"/>
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook45-profile.xsl"
             uri="profiling/docbook45-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
@@ -67,7 +67,7 @@
             uri="profiling/docbook50-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook50-profile.xsl"
             uri="profiling/docbook50-profile.xsl" />
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook50-profile.xsl"
             uri="profiling/docbook50-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
@@ -76,7 +76,7 @@
             uri="profiling/docbook51-profile.xsl"/>
     <system systemId="urn:x-daps:xslt:profiling:docbook51-profile.xsl"
             uri="profiling/docbook51-profile.xsl" />
-    <uri name="urn:x-daps:xslt:profiling:docbook41-profile.xsl"
+    <uri name="urn:x-daps:xslt:profiling:docbook51-profile.xsl"
             uri="profiling/docbook51-profile.xsl"/>
 
     <system systemId="urn:x-suse:xslt:profiling:novdoc-profile.xsl"


### PR DESCRIPTION
This PR changes some typos in our catalogs. The original text looked very fishy, so I'm quite sure this fix is correct. Luckily, those URNs were never used. :wink: 