### PR TITLE
First draft to support DocBook assemblies

### DIFF
--- a/bin/daps.in
+++ b/bin/daps.in
@@ -62,6 +62,9 @@ VARLIST=(
     ADOC_SET
     ADOC_TYPE
     ASCIIDOC
+    ASSEMBLY
+    ASSEMBLY_DIR
+    ASSEMBLY_MAIN
     SPELL_CHECKER
     SPELL_EXTRA_DICT
     SPELL_LANG
@@ -1458,13 +1461,20 @@ fi
 # Validate SRC_FORMAT - needs to be xml or adoc
 [[ "adoc" = "$SRC_FORMAT" || "xml" = "$SRC_FORMAT" ]] || exit_on_error "$MAIN is an unsupported file type (.$SRC_FORMAT)\nmust be AsciiDoc (.adoc) or DocBook (.xml)"
 
-# Check whether "${DOC_DIR}/${SRC_FORMAT}" exists
-[[ -d "${DOC_DIR}/${SRC_FORMAT}" ]] || exit_on_error "Source files must reside in  \"${DOC_DIR}/${SRC_FORMAT}/\".\n This directory does not exist."
+# Check whether "${DOC_DIR}/${SRC_FORMAT}" or "${DOC_DIR}/$ASSEMBLY_DIR" exists
+if [[ "yes" == "$ASSEMBLY" ]]; then
+    [[ -d "${DOC_DIR}/${ASSEMBLY_DIR}" ]] || exit_on_error "ASSEMBLY_DIR points to a non existing directory"
+else
+    [[ -d "${DOC_DIR}/${SRC_FORMAT}" ]] || exit_on_error "Source files must reside in  \"${DOC_DIR}/${SRC_FORMAT}/\".\n This directory does not exist."
+fi
 
 # Set MAIN if necessary
 if [[ -z "$MAIN_CMDL" ]]; then
+    # assembly without an absolute path
+    if [[ "yes" == "$ASSEMBLY" && -n "$ASSEMBLY_DIR" && ! "$MAIN" =~ ^/ ]]; then
+        MAIN="${DOC_DIR}/${ASSEMBLY_DIR}/$MAIN"
     # MAIN was provided without any path
-    if [[ -e "${DOC_DIR}/${SRC_FORMAT}/$MAIN" ]]; then
+    elif [[ -e "${DOC_DIR}/${SRC_FORMAT}/$MAIN" ]]; then
         MAIN="${DOC_DIR}/${SRC_FORMAT}/$MAIN"
     # MAIN was provided with a relative path
     elif [[ -e "${DOC_DIR}/$MAIN" ]]; then
@@ -1707,8 +1717,8 @@ export SETFILES_TMP
 #
 if [[ "adoc" = "$SRC_FORMAT" ]]; then
     ADOC_MAIN="$MAIN"
-    ADOC_DIR="${BUILD_DIR}/.adoc"
-    MAIN="${ADOC_DIR}/${BOOK}.xml"
+    ADOC_RESULTDIR="${BUILD_DIR}/.adoc"
+    MAIN="${ADOC_RESULTDIR}/${BOOK}.xml"
 
     # make the path for ADOC_IMG_DIR absolute if a relative path was
     # provided by config file
@@ -1723,12 +1733,34 @@ if [[ "adoc" = "$SRC_FORMAT" ]]; then
             [[ ! -d $ADOC_IMG_DIR ]] && exit_on_error "AsciiDoc image directory $ADOC_IMG_DIR does not exist"
         fi
     fi
-    export ADOC_IMG_DIR ADOC_MAIN ADOC_DIR MAIN
+    export ADOC_IMG_DIR ADOC_MAIN ADOC_RESULTDIR MAIN
+    # we always want to create a fresh bigfile
     [[ 1 -eq $FORCE_REBUILD ]] && MOPTS="--always-make"
     [[ 2 -gt $VERBOSITY ]] && MOPTS="$MOPTS --silent"
 
     make $MOPTS -f $DAPSROOT/make/adoc2xml.mk  || exit_on_error "\nConverting the AsciiDoc sources to XML caused a fatal error.\nCheck the $(basename ${ASCIIDOC}) message above for details."
 fi
+
+#-------------------------------------------------------------------
+# Create an XML bigfile from an assembly
+#
+if [[ "yes" == "$ASSEMBLY" ]]; then
+
+    ASSEMBLY_MAIN="$MAIN"
+    ASSEMBLY_RESULTDIR="${BUILD_DIR}/.assembly"
+    MAIN="${ASSEMBLY_RESULTDIR}/${BOOK}.xml"
+
+    export ASSEMBLY_MAIN ASSEMBLY_RESULTDIR MAIN
+
+    # Since we do not have a list of files used from the assembly, we always
+    # need to rebuild.
+    MOPTS="--always-make"
+    [[ 2 -gt $VERBOSITY ]] && MOPTS="$MOPTS --silent"
+
+    make $MOPTS -f $DAPSROOT/make/assembly2db.mk  || exit_on_error "\nConverting the assembly to DocBook caused a fatal error."
+fi
+
+
 
 #-------------------------------------------------------------------
 # Check whether the document is _well-formed_ (but not whether they

--- a/bin/daps.in
+++ b/bin/daps.in
@@ -1463,7 +1463,7 @@ fi
 
 # Check whether "${DOC_DIR}/${SRC_FORMAT}" or "${DOC_DIR}/$ASSEMBLY_DIR" exists
 if [[ "yes" == "$ASSEMBLY" ]]; then
-    [[ -d "${DOC_DIR}/${ASSEMBLY_DIR}" ]] || exit_on_error "ASSEMBLY_DIR points to a non existing directory"
+    [[ -d "${DOC_DIR}/${ASSEMBLY_DIR}" ]] || exit_on_error "ASSEMBLY_DIR points to a non-existing directory"
 else
     [[ -d "${DOC_DIR}/${SRC_FORMAT}" ]] || exit_on_error "Source files must reside in  \"${DOC_DIR}/${SRC_FORMAT}/\".\n This directory does not exist."
 fi

--- a/daps-xslt/common/get-language.xsl
+++ b/daps-xslt/common/get-language.xsl
@@ -2,24 +2,24 @@
 <!--
    Purpose:
      Extract language from @lang or @xml:lang attributes
-     
+
    Parameters:
      * allowed.roots (string)
        String of allowed root elements, separated by spaces.
        Use the local name (without any namespace prefixes).
-       
+
    Input:
      DocBook 4 or DocBook 5 documents with book, article, or
      chapter as root element.
-     
+
    Output:
      String of the found language
-      If the root element is not equal to book or book doesn't 
+      If the root element is not equal to book or book doesn't
       contain a lang attribute, it will print an error.
-   
+
    Author:    Thomas Schraitle <toms@opensuse.org>
    Copyright (C) 2012-2020 SUSE Software Solutions Germany GmbH
-   
+
 -->
 <xsl:stylesheet version="1.0"
    xmlns:db="http://docbook.org/ns/docbook"
@@ -27,9 +27,9 @@
 
 <xsl:output method="text"/>
 
-<xsl:param name="allowed.roots">appendix article bibliography book chapter
- glossary glossdiv part preface qandaset reference refsect1 refsect2 refsect3
- refsection sect1 sect2 sect3 sect4 sect5 section set</xsl:param>
+<xsl:param name="allowed.roots">appendix article assembly bibliography book
+chapter glossary glossdiv part preface qandaset reference refsect1 refsect2
+refsect3 refsection sect1 sect2 sect3 sect4 sect5 section set</xsl:param>
 
 
 <xsl:template match="/">

--- a/etc/config.in
+++ b/etc/config.in
@@ -192,7 +192,7 @@ ADOC_TYPE="article"
 ## Type:        yesno
 ## Default:     no
 #
-# Allows to completely separate the output daps generates from the sources
+# Allows to completely separate the output daps generates from the sources.
 # If not set it is automatically resolved to $DOC_DIR/build/$BOOK
 #
 # Also see ASSEMBLY_SRCDIR

--- a/etc/config.in
+++ b/etc/config.in
@@ -186,6 +186,34 @@ ADOC_SET_STYLE="@pkgdatadir@/daps-xslt/asciidoc/setify.xsl"
 #
 ADOC_TYPE="article"
 
+## Key:         ASSEMBLY
+## ----------------------
+## Description: Build from a DocBook assembly
+## Type:        yesno
+## Default:     no
+#
+# Allows to completely separate the output daps generates from the sources
+# If not set it is automatically resolved to $DOC_DIR/build/$BOOK
+#
+# Also see ASSEMBLY_SRCDIR
+#
+ASSEMBLY="no"
+
+## Key:         ASSEMBLY_DIR
+## ----------------------------
+## Description: Directory containing the assembly file
+## Type:        Path to directory (without a trailing slash)
+## Default:     ""
+#
+# Path to the directory containing the assembly file specified with
+# MAIN. Will be ignored if ASSEMBLY is not set to "yes"
+#
+# Also see ASSEMBLY
+#
+ASSEMBLY_DIR=""
+
+
+
 ## Key:         BUILD_DIR
 ## ----------------------
 ## Description: Build directory where all daps generated files will go

--- a/make/adoc2xml.mk
+++ b/make/adoc2xml.mk
@@ -131,17 +131,7 @@ ifneq "$(strip $(ADOC_IMG_DIR))" ""
   all: $(NEW_IMAGES)
 endif
 
-#
-# Since asciidoctor only refuses to write a file on FATAL errors
-# (but we already exit on ERROR and WARN), we always need to rebuild
-# MAIN. According to https://stackoverflow.com/questions/7643838/how-to-force-make-to-always-rebuild-a-file
-# this should do the trick
-#
 
-.PHONY: FORCE
-FORCE:
-
-#
 # If ADOC_SET is set to 1 (and we are to create a set from an AsciiDoc
 # multipart book), pipe the asciidoctor output to an xsltproc call
 # runinng the "setify" stylesheet, otherwise let asciidoctor create
@@ -151,7 +141,7 @@ FORCE:
 # returns != 0
 
 #all: $(MAIN)
-$(MAIN): FORCE $(ADOC_SRCFILES) | $(ADOC_DIR)
+$(MAIN): $(ADOC_SRCFILES) | $(ADOC_RESULTDIR)
   ifeq "$(VERBOSITY)" "2"
 	@ccecho "info"  "   Creating XML from AsciiDoc..."
   endif
@@ -194,5 +184,5 @@ $(PNG_DIR)/%.png: $(ADOC_IMG_DIR)/%.png | $(PNG_DIR)
 $(SVG_DIR)/%.svg: $(ADOC_IMG_DIR)/%.svg | $(SVG_DIR)
 	(cd $(@D); ln -sf $<)
 
-$(ADOC_DIR) $(NEW_IMAGES_DIRS):
+$(ADOC_RESULTDIR) $(NEW_IMAGES_DIRS):
 	@mkdir -p $@

--- a/make/assembly2db.mk
+++ b/make/assembly2db.mk
@@ -1,0 +1,59 @@
+# Copyright (C) 2012-2022 SUSE Software Solutions Germany GmbH
+#
+# Author:
+# Frank Sundermeyer <fsundermeyer at opensuse dot org>
+#
+# Convert DocBook assemblies to a DocBook bigfile ("realized XML")
+#
+# Please submit feedback or patches to
+# <fsundermeyer at opensuse dot org>
+#
+
+include $(DAPSROOT)/make/common_variables.mk
+
+# Stylesheets and Settings
+
+STYLEASSEMBLY  := $(firstword $(wildcard $(addsuffix \
+	        /assembly/assemble.xsl, $(STYLE_ROOTDIRS))))
+
+# used to select one structure among several (if assembly file provides
+# multiple structures)
+# Let's use ROOTID for this purpose
+#
+ifneq "$(strip $(ROOTID))" ""
+  ASSEMBLYSTRINGS := --stringparam "structure.id=$(ROOTID)"
+endif
+
+# Since we do not have a list of files used from the assembly, we always need
+# to rebuild. According to
+# https://stackoverflow.com/questions/7643838/how-to-force-make-to-always-rebuild-a-file
+# this should do the trick
+#
+
+#.PHONY: FORCE
+#FORCE:
+
+#
+# If ADOC_SET is set to 1 (and we are to create a set from an AsciiDoc
+# multipart book), pipe the asciidoctor output to an xsltproc call
+# runinng the "setify" stylesheet, otherwise let asciidoctor create
+# the file directly
+#
+# set -o pipefail makes sure make exits when the asciidoctor command
+# returns != 0
+
+#all: $(MAIN)
+$(MAIN): $(ASSEMBLY_MAIN) | $(ASSEMBLY_RESULTDIR)
+  ifeq "$(VERBOSITY)" "2"
+	@ccecho "info"  "   Creating XML bigfile from assembly..."
+  endif
+	$(XSLTPROC) $(ASSEMBLYSTRINGS) $(XSLTPARAM) $(PARAMS) \
+	    $(STRINGPARAMS) --output $@ --stylesheet $(STYLEASSEMBLY) \
+	    --file $< $(XSLTPROCESSOR) $(DEVNULL) \
+	    $(ERR_DEVNULL);
+  ifeq "$(VERBOSITY)" "2"
+	@ccecho "info" "Successfully created XML bigfile $@"
+  endif
+
+$(ASSEMBLY_RESULTDIR):
+	@mkdir -p $@

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -13,7 +13,8 @@
 clean:
 	rm -rf $(PROFILE_PARENT_DIR)
 	rm -rf $(TMP_DIR)
-	rm -rf $(ADOC_DIR)
+	rm -rf $(ADOC_RESULTDIR)
+	rm -rf $(ASSEMBLY_RESULTDIR)
 	@ccecho "info" "Successfully removed all profiled and temporary files."
 
 .PHONY: clean-images

--- a/make/common_variables.mk
+++ b/make/common_variables.mk
@@ -385,9 +385,15 @@ endif
 # For use in filenames we keep the capitalization as is (LANGSTRING), for
 # use in stylessheets we convert it to all lowercase (the same way the Docbook
 # Stylesheets do)
-#
+# If we have an assembly, look into the assembly file
 
-XMLLANG ?= $(shell $(XSLTPROC) --stylesheet $(STYLELANG) --file $(MAIN) $(XSLTPROCESSOR) | tr - _ 2>/dev/null)
+ifeq "$(strip $(ASSEMBLY))" "yes"
+  LANG_MAIN := $(ASSEMBLY_MAIN)
+else
+  LANG_MAIN := $(MAIN)
+endif
+
+XMLLANG ?= $(shell $(XSLTPROC) --stylesheet $(STYLELANG) --file $(LANG_MAIN) $(XSLTPROCESSOR) | tr - _ 2>/dev/null)
 
 ifneq "$(strip $(XMLLANG))" ""
   LL ?= $(shell tr '[:upper:]' '[:lower:]' <<< $(XMLLANG) 2>/dev/null)

--- a/make/setfiles.mk
+++ b/make/setfiles.mk
@@ -36,7 +36,10 @@ ifeq "$(strip $(SRC_FORMAT))" "xml"
   XML_SRC_PATH := $(DOC_DIR)/xml/
 endif
 ifeq "$(strip $(SRC_FORMAT))" "adoc"
-  XML_SRC_PATH := $(ADOC_DIR)/
+  XML_SRC_PATH := $(ADOC_RESULTDIR)/
+endif
+ifeq "$(strip $(ASSEMBLY))" "yes"
+  XML_SRC_PATH := $(ASSEMBLY_RESULTDIR)/
 endif
 
 SETFILES := $(shell $(XSLTPROC) $(PROFSTRINGS) \


### PR DESCRIPTION
* profiling does not work, yet (needs fixing #529)
* renamed ADOC_DIR to ADOC_RESULTDIR for consistency

Requires to specify a custom directory where the topic files
are located. This should also be supported for xml and adoc for
consistency. All directories variables used in make should also
have the same name everywhere, regardless of the source format.
Will require a major code overhaul.