### PR TITLE
Always rebuild by default (make --always-make)

### DIFF
--- a/bin/daps.in
+++ b/bin/daps.in
@@ -550,7 +550,9 @@ Global Options:
                             Useful if you have forks of your custom
                             stylesheets.
   --force                   Force a rebuild of the document even when an
-                            up-to-date version exists.
+                            up-to-date version exists. This is the default.
+                            If the config was changed to not rebuild
+                            (ALWAYS_REBUILD="no"), use this option to override.
   --help, -h                Help
   --jobs=X                  Specify how many parallel jobs to use. Higher
                             numbers will significantly increase the processing

--- a/etc/config.in
+++ b/etc/config.in
@@ -186,6 +186,22 @@ ADOC_SET_STYLE="@pkgdatadir@/daps-xslt/asciidoc/setify.xsl"
 #
 ADOC_TYPE="article"
 
+## Key:         ALWAYS_REBUILD
+## ----------------------
+## Description: Always rebuild all files even when up-to-date versions exist
+## Type:        yesno
+## Default:     "yes"
+#
+# DAPS uses GNU make to generate all files. make keeps track of files and
+# dependencies and only rebuilds files if necessary (when their dependencies
+# have changed). This saves time, especially wit large projects that have a
+# lot of images.
+# If consecutive builds take a very long time, try setting this to "no"
+# (preferrably in the DC-file or in ~/.config/daps/dapsrc)
+# A "no" can be overwritten with --force on the command line at any time.
+#
+ALWAYS_REBUILD="yes"
+
 ## Key:         BUILD_DIR
 ## ----------------------
 ## Description: Build directory where all daps generated files will go

--- a/lib/daps_functions
+++ b/lib/daps_functions
@@ -642,8 +642,8 @@ function call_make {
         MAKE_OPTIONS="$MAKE_OPTIONS -j1"
     fi
 
-    # Is --force set to force a rebuild?
-    [[ 1 -eq $FORCE_REBUILD ]] &&  MAKE_OPTIONS="$MAKE_OPTIONS --always-make"
+    # Is --force or ALWAYS_REMAKE set to force a rebuild?
+    [[ 1 -eq $FORCE_REBUILD || "yes" == "$ALWAY_MAKE" ]] &&  MAKE_OPTIONS="$MAKE_OPTIONS --always-make"
 
     MAKE_CMD="$MAKE_BIN $MAKE_OPTIONS $SUB_CMD $*"
 

--- a/man/xml/daps.xml
+++ b/man/xml/daps.xml
@@ -213,7 +213,9 @@
     <term><option>--force</option></term>
     <listitem>
      <para>
-      Force a rebuild of the document even when an up-to-date version exists.
+      Force a rebuild of the document even when an up-to-date version
+      exists. This is the default. If the config was changed to not rebuild
+      (ALWAYS_REBUILD="no"), use this option to override.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Always rebuild all files even when they are up-to-date. This feature ca be
controlled by ALWAYS_REBUILD in /etc/daps/config, the user config or the
DC file. Possible values: "yes" (new default) and "no" (previous default on
all DAPS versions)

This change is a proposal, because sometimes the "do nor rebuild" feature causes confusion. Build time does no longer seem to be a big issue on modern multi.processor machines, so we may as well change the default here.

Fell free to reject the PR if you disagree, code changes are minimal.