### PR TITLE
Add registration of Poppins to fop config files

### DIFF
--- a/etc/fop/fop-daps.generic
+++ b/etc/fop/fop-daps.generic
@@ -1,12 +1,12 @@
 <!--<!DOCTYPE configuration SYSTEM "config.dtd">-->
-<!-- 
-     this file contains templates which allow an user easy 
-     configuration of Fop. Actually normally you don't need this configuration 
+<!--
+     this file contains templates which allow an user easy
+     configuration of Fop. Actually normally you don't need this configuration
      file, but if you need to change configuration, you should
-     always use this file and *not* config.xml. 
+     always use this file and *not* config.xml.
      Usage:
      java org.apache.fop.apps.Fop -c userconfig.xml -fo fo-file -pdf pdf-file
-     
+
      See also:
      http://xmlgraphics.apache.org/fop/1.0/configuration.html
 -->
@@ -21,7 +21,72 @@
      -->
      <directory>/usr/share/fonts/truetype/</directory>
      <!-- automatically detect operating system installed fonts -->
-     <auto-detect/>  
+     <auto-detect/>
+     <!--
+        Register the font Poppins manually, since the font auto-detection doesn't work
+        for Poppins. Once it is updated by upstream this following block can be removed.
+        https://issues.apache.org/jira/browse/FOP-3045
+     -->
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Thin.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ThinItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraLight.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraLightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Light.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-LightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Medium.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-MediumItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-SemiBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-SemiBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Bold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-BoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Black.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="900" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-BlackItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="900" />
+     </font>
    </fonts>
   </renderer>
 

--- a/etc/fop/fop-daps.redhat
+++ b/etc/fop/fop-daps.redhat
@@ -1,12 +1,12 @@
 <!--<!DOCTYPE configuration SYSTEM "config.dtd">-->
-<!-- 
-     this file contains templates which allow an user easy 
-     configuration of Fop. Actually normally you don't need this configuration 
+<!--
+     this file contains templates which allow an user easy
+     configuration of Fop. Actually normally you don't need this configuration
      file, but if you need to change configuration, you should
-     always use this file and *not* config.xml. 
+     always use this file and *not* config.xml.
      Usage:
      java org.apache.fop.apps.Fop -c userconfig.xml -fo fo-file -pdf pdf-file
-     
+
      See also:
      http://xmlgraphics.apache.org/fop/1.0/configuration.html
 -->
@@ -18,7 +18,72 @@
      <directory recursive="true">/usr/share/fonts/</directory>
 
      <!-- automatically detect operating system installed fonts -->
-     <auto-detect/>  
+     <auto-detect/>
+     <!--
+        Registering the font Poppins manually, since the FOP Auto-Detect mechanism doesn't work
+        for Poppins. Once it is updated from upstream this following block can be removed.
+        https://issues.apache.org/jira/browse/FOP-3045
+     -->
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Thin.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-ThinItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-ExtraLight.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-ExtraLightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Light.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-LightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Medium.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-MediumItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-SemiBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-SemiBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Bold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-BoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-ExtraBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-ExtraBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-Black.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="900" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/Poppins-BlackItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="900" />
+     </font>
    </fonts>
   </renderer>
  </renderers>

--- a/etc/fop/fop-daps.suse
+++ b/etc/fop/fop-daps.suse
@@ -1,12 +1,12 @@
 <!--<!DOCTYPE configuration SYSTEM "config.dtd">-->
-<!-- 
-     this file contains templates which allow an user easy 
-     configuration of Fop. Actually normally you don't need this configuration 
+<!--
+     this file contains templates which allow an user easy
+     configuration of Fop. Actually normally you don't need this configuration
      file, but if you need to change configuration, you should
-     always use this file and *not* config.xml. 
+     always use this file and *not* config.xml.
      Usage:
      java org.apache.fop.apps.Fop -c userconfig.xml -fo fo-file -pdf pdf-file
-     
+
      See also:
      http://xmlgraphics.apache.org/fop/1.0/configuration.html
 -->
@@ -17,14 +17,80 @@
  <renderers>
   <renderer mime="application/pdf">
    <fonts>
-    <!--
+     <!--
         register all the fonts found in a directory
         use recursive="true" to also include subdirectories
      -->
      <directory>/usr/share/fonts/truetype/</directory>
 
      <!-- automatically detect operating system installed fonts -->
-     <auto-detect/>  
+     <auto-detect/>
+
+     <!--
+        Register the font Poppins manually, since the font auto-detection doesn't work
+        for Poppins. Once it is updated by upstream this following block can be removed.
+        https://issues.apache.org/jira/browse/FOP-3045
+     -->
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="normal" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Thin.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ThinItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="100" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraLight.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraLightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="200" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Light.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-LightItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="300" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Regular.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Italic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="400" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Medium.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-MediumItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="500" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-SemiBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-SemiBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="600" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Bold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-BoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="700" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraBold.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-ExtraBoldItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="800" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-Black.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="normal" weight="900" />
+     </font>
+     <font kerning="yes" embed-url="/usr/share/fonts/truetype/Poppins-BlackItalic.ttf" simulate-style="false" embedding-mode="subset">
+      <font-triplet name="Poppins" style="italic" weight="900" />
+     </font>
    </fonts>
   </renderer>
  </renderers>


### PR DESCRIPTION
Register the font Poppins manually, since the font auto-detection of FOP doesn't work for Poppins.

Fix: openSUSE/suse-xsl#447