### PR TITLE
Add test for xincluded file with missing entity

### DIFF
--- a/python-scripts/daps-xmlwellformed/tests/data/bad/para-included.xml
+++ b/python-scripts/daps-xmlwellformed/tests/data/bad/para-included.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE para [
+ <!ENTITY ent SYSTEM "missing-entity.ent">
+ %ent;
+]>
+
+<para version="5.2"
+  xmlns="http://docbook.org/ns/docbook">
+
+</para>

--- a/python-scripts/daps-xmlwellformed/tests/data/bad/test-xinclude-file-not-found-missing-entity-file.xml
+++ b/python-scripts/daps-xmlwellformed/tests/data/bad/test-xinclude-file-not-found-missing-entity-file.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<article version="5.0"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude">
+  <title>XInclude with pointer to non-existent file</title>
+  <para/>
+  <xi:include href="para-included.xml"/>
+</article>

--- a/python-scripts/daps-xmlwellformed/tests/test_xml-bad.py
+++ b/python-scripts/daps-xmlwellformed/tests/test_xml-bad.py
@@ -113,6 +113,33 @@ def test_xinclude_errors(xmlfile, messages, caplog):
     with caplog.at_level(logging.ERROR):
         result = dxwf.check_wellformedness(xmlfile, xinclude=True)
 
+    # Then
     assert len(caplog.records) == len(messages)
     for record, pattern in zip(caplog.records, messages):
         assert re.search(pattern, record.msg)
+
+
+
+def test_xinclude_file_not_found_missing_entity_file(caplog):
+    # Given
+    xmlfile = str(BADDIR /
+                  "test-xinclude-file-not-found-missing-entity-file.xml")
+    expected_return_codes = (logging.getLevelName(logging.FATAL),
+                             logging.getLevelName(logging.ERROR)
+                             )
+    
+    # When
+    with caplog.at_level(logging.ERROR):
+        result = dxwf.check_wellformedness(xmlfile, xinclude=True)
+    
+    # Then
+    assert caplog.records
+    assert len(caplog.records) == len(expected_return_codes)
+
+    records = caplog.records
+    return_codes = tuple([logging.getLevelName(getattr(logging, record.levelname))
+                          for record in caplog.records])
+    assert return_codes == expected_return_codes
+
+    # for record in caplog.records:
+    #    print(record)


### PR DESCRIPTION
This PR tests a file which is xincluded, but refers to a missing entity file:

