### PR TITLE
Use 2 space indent for XML sources

### DIFF
--- a/etc/docbook-xmlformat-1.9.conf
+++ b/etc/docbook-xmlformat-1.9.conf
@@ -3,7 +3,7 @@
 
 *DEFAULT
   wrap-type     none
-
+  subindent     2
 
 # Block elements
 ackno address appendix article biblioentry bibliography bibliomixed \


### PR DESCRIPTION
Fixes SUSE/doc-styleguide#141