### PR TITLE
convert usage of egrep to grep -E boo#1203092

### DIFF
--- a/bin/daps.in
+++ b/bin/daps.in
@@ -297,8 +297,8 @@ else
 fi
 
 # Set the maximum number of concurrent jobs to the number of cores
-# If egrep does not return something useful, set it to "2" as a sane default
-JOBS=$(egrep -s -m1 "cpu cores\s*:" /proc/cpuinfo 2>/dev/null | sed 's/cpu cores\s*:\s*//')
+# If grep -E does not return something useful, set it to "2" as a sane default
+JOBS=$(grep -E -s -m1 "cpu cores\s*:" /proc/cpuinfo 2>/dev/null | sed 's/cpu cores\s*:\s*//')
 [[ -z $JOBS ]] && JOBS=2
 
 #---------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -415,9 +415,9 @@ AM_CONDITIONAL([HAS_DAPS_XSL], [test -d $daps_xsl])
 
 dnl -------------------------------------------------------------------------
 dnl Add more distributions if needed
-AM_CONDITIONAL([DIST_REDHAT], [egrep -iq "^NAME=\"?(fedora|redhat)\"?" /etc/os-release])
-AM_CONDITIONAL([DIST_SUSE], [egrep -iq "^NAME=\"?(opensuse|sles|sled)\"?" /etc/os-release])
-AM_CONDITIONAL([DIST_DEBIAN], [egrep -iq "^NAME=\"?(ubuntu|debian)\"?" /etc/os-release])
+AM_CONDITIONAL([DIST_REDHAT], [grep -E -iq "^NAME=\"?(fedora|redhat)\"?" /etc/os-release])
+AM_CONDITIONAL([DIST_SUSE], [grep -E -iq "^NAME=\"?(opensuse|sles|sled)\"?" /etc/os-release])
+AM_CONDITIONAL([DIST_DEBIAN], [grep -E -iq "^NAME=\"?(ubuntu|debian)\"?" /etc/os-release])
 
 dnl -------------------------------------------------------------------------
 dnl Set a conditional to determine whether ADOC is supported

--- a/contrib/translation/extract_translators.sh
+++ b/contrib/translation/extract_translators.sh
@@ -152,7 +152,7 @@ for FILE in ${DATA_DIR}/*.po; do
 	# Strings are ignored and an error message is printed to STDERR
         #
 	# two email addresses => entries have not been separated with ";"
-	egrep -sq "[^@]*@[^@]*@" <<< "$TRANS"  >/dev/null 2>&1
+	grep -E -sq "[^@]*@[^@]*@" <<< "$TRANS"  >/dev/null 2>&1
 	if [[ 0 -eq $? ]]; then
 	    echo -e "Format error in $FILE: $TRANSL" >&2
 	    continue
@@ -171,7 +171,7 @@ for FILE in ${DATA_DIR}/*.po; do
 	fi
 
 	# extract year(s)
-	# expr can only handle basic regexp, so let's use egrep here
+	# expr can only handle basic regexp, so let's use grep -E here
 	# the regexp catches the following occurences:
         # <DATA>, YEAR
 	# <DATA>,YEAR
@@ -186,7 +186,7 @@ for FILE in ${DATA_DIR}/*.po; do
 	# <DATA>,YEAR - YEAR
 	# ...
 	# and the same variant with with YEAR following DATA
-        YEAR=$(egrep -o "([，, ] *[[:digit:]]{4}( *[，, -] *[[:digit:]]{4})?|^[[:digit:]]{4}( *[，, -] *)?([[:digit:]]{4})?)" <<< "$TRANS" )
+        YEAR=$(grep -E -o "([，, ] *[[:digit:]]{4}( *[，, -] *[[:digit:]]{4})?|^[[:digit:]]{4}( *[，, -] *)?([[:digit:]]{4})?)" <<< "$TRANS" )
 	if [[ -n $YEAR ]]; then
 	    # Remove year from TRANSL string
 	    TRANSL=${TRANSL/"$YEAR"/}

--- a/make/adoc2xml.mk
+++ b/make/adoc2xml.mk
@@ -96,7 +96,7 @@ endif
 # If grep fails, we at least have ADOC_MAIN
 #
 ADOC_SRCFILES := $(ADOC_MAIN) $(wildcard $(addprefix \
- $(DOC_DIR)/adoc/,$(shell egrep '^include::' $(ADOC_MAIN) 2>/dev/null | sed 's/.*::\([^\[]*\).*/\1/g' 2>/dev/null)))
+ $(DOC_DIR)/adoc/,$(shell grep -E '^include::' $(ADOC_MAIN) 2>/dev/null | sed 's/.*::\([^\[]*\).*/\1/g' 2>/dev/null)))
 #ADOC_SRCFILES := $(wildcard $(DOC_DIR)/adoc/*.adoc)
 
 #

--- a/test/lib/005_profiling
+++ b/test/lib/005_profiling
@@ -101,7 +101,7 @@ function test_profilingFilelist () {
 # Have the entities been resolved?
 #
 function test_profilingEntities () {
-    egrep -q "&ent[0-9];" ${_PROFILEDIR}/*.xml 2>/dev/null
+    grep -E -q "&ent[0-9];" ${_PROFILEDIR}/*.xml 2>/dev/null
     assertFalse \
         ' └─ Not all entities have been resolved' \
         "$?"
@@ -194,7 +194,7 @@ function test_profilingContent () {
     clean_build_dir profiles
     _PROFILEDIR=$($_DAPSEXEC -v0 --main $_MAIN_PROFILING showvariable VARIABLE=PROFILEDIR)
     $_DAPSEXEC -v0 --main $_MAIN_PROFILING profile >/dev/null 2>&1
-    _COUNT=$(egrep "(arch|condition|os|vendor)=(arch|condition|os|vendor)[12]" \
+    _COUNT=$(grep -E "(arch|condition|os|vendor)=(arch|condition|os|vendor)[12]" \
         ${_PROFILEDIR}/*.xml 2>/dev/null | wc -l)
     assertEquals \
         ' └─ Content has been filtered from XML although no profiling attribute was set' \
@@ -206,7 +206,7 @@ function test_profilingContent () {
     clean_build_dir profiles
     _PROFILEDIR=$($_DAPSEXEC -v0 --main $_MAIN_PROFILING showvariable VARIABLE=PROFILEDIR PROFARCH=foo PROFCONDITION=foo PROFOS=foo PROFVENDOR=foo)
     $_DAPSEXEC -v0 --main $_MAIN_PROFILING profile PROFARCH=foo PROFCONDITION=foo PROFOS=foo PROFVENDOR=foo >/dev/null 2>&1
-    egrep "(arch|condition|os|vendor)=(arch|condition|os|vendor)[12]" \
+    grep -E "(arch|condition|os|vendor)=(arch|condition|os|vendor)[12]" \
         ${_PROFILEDIR}/*.xml >/dev/null 2>&1
     assertFalse \
         ' └─ Profiled XML contains content that should have been filtered (all profiling variables have been set to a value that has no match in the XML)' \

--- a/test/lib/020_pdf
+++ b/test/lib/020_pdf
@@ -114,7 +114,7 @@ function test_pdfStyleroot () {
     #
 
     $_DAPSEXEC -d $_DCFILE --styleroot=${_DOC_DIR} --fb_styleroot=${_STANDARD_STYLES} --debug pdf >/dev/null 2>&1
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Fallback Styleroot specified on the command line was not used." \
         "$?"
@@ -135,7 +135,7 @@ function test_pdfStyleroot () {
     # Testing Styleroot specified with --styleroot
     #
     $_DAPSEXEC -d $_DCFILE --styleroot ${_STANDARD_STYLES} --debug pdf >/dev/null 2>&1
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Styleroot specified on the command line was not used." \
         "$?"
@@ -173,7 +173,7 @@ function test_pdfGrayscaleCropmarks () {
        "$_PDF_NAME_PATH" "$_PDF_BUILD_PATH"
 
    # Check for the format.print parameter
-   egrep -q -- "--param\s+\"format\.print=1\"" $_LOGFILE 2>/dev/null
+   grep -E -q -- "--param\s+\"format\.print=1\"" $_LOGFILE 2>/dev/null
    assertTrue \
        ' └─ Param format.print=1 is not specified when generating the FO-file' \
        "$?"
@@ -190,7 +190,7 @@ function test_pdfGrayscaleCropmarks () {
     # Check cropmarks (for XEP only)
     [[ fop == $_FOPROC ]] && startSkipping
 
-    egrep -q -- "--param\s+\"crop\.marks=1\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--param\s+\"crop\.marks=1\"" $_LOGFILE 2>/dev/null
     assertTrue \
        ' └─ Param crop.marks=1 is not specified when generating the FO-file' \
        "$?"
@@ -234,7 +234,7 @@ function test_pdfRemarksDraftMeta () {
 
    # checking DRAFT mode
    #
-   egrep -q -- "--stringparam\s+\"draft\.mode=yes\"" $_LOGFILE 2>/dev/null
+   grep -E -q -- "--stringparam\s+\"draft\.mode=yes\"" $_LOGFILE 2>/dev/null
    assertTrue \
        ' └─ Stringparam for DRAFT mode is not correctly specified when generating the FO-file' \
        "$?"
@@ -247,7 +247,7 @@ function test_pdfRemarksDraftMeta () {
    # --param "show.comments=1" needs to occur once for each XML file on
    # profiling and another time when creating the fo-file
    #
-   _REMARK_COUNT_ACTUAL=$(egrep -c -- "--param\s+\"show\.comments=1\"" $_LOGFILE)
+   _REMARK_COUNT_ACTUAL=$(grep -E -c -- "--param\s+\"show\.comments=1\"" $_LOGFILE)
    let "_REMARK_COUNT_EXPECTED=${#_XML_FILES[@]} + 1"
    assertEquals \
        " └─ --param \"show.comments=1\" appears less often in the log file than expected" \
@@ -317,7 +317,7 @@ function test_pdfRootidXsltparam () {
     assertTrue \
         ' └─ Building a pdf with --rootid and --param failed ' \
        "$?"
-    egrep -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
     assertTrue \
         ' └─ Stringparam for ROOTID is not correctly specified when generating the FO-file' \
         "$?"
@@ -334,7 +334,7 @@ function test_pdfRootidXsltparam () {
         "$_PAGECOUNT_EXPECTED" "$_PAGECOUNT"
 
     # check xsltparam
-    egrep -q -- "$_XSLTPARAM" $_LOGFILE 2>/dev/null
+    grep -E -q -- "$_XSLTPARAM" $_LOGFILE 2>/dev/null
     assertTrue \
         ' └─ Param for XSLTPARAM is not correctly specified when generating the FO-file' \
         "$?"

--- a/test/lib/022_html
+++ b/test/lib/022_html
@@ -185,7 +185,7 @@ function test_htmlRemarksDraftMeta () {
 
    # checking DRAFT mode
    #
-   egrep -q -- "background-image.*draft.png" ${_HTML_BUILD_PATH}/index.html 2>/dev/null
+   grep -E -q -- "background-image.*draft.png" ${_HTML_BUILD_PATH}/index.html 2>/dev/null
    assertTrue \
        ' └─ Generated HTML does not seem to have a DRAFT bg-image' \
        "$?"
@@ -401,7 +401,7 @@ function test_htmlRootidXsltparam () {
         ' └─ Building a html document with --rootid and --param failed ' \
        "$?"
 
-    egrep -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
     assertTrue \
         ' └─ Stringparam for ROOTID is not correctly specified when generating the FO-file' \
         "$?"
@@ -428,7 +428,7 @@ function test_htmlRootidXsltparam () {
         "$?"
 
     # check xsltparam
-    egrep -q -- "$_XSLTPARAM" $_LOGFILE 2>/dev/null
+    grep -E -q -- "$_XSLTPARAM" $_LOGFILE 2>/dev/null
     assertTrue \
         ' └─ Param for XSLTPARAM is not correctly specified when generating HTML' \
         "$?"
@@ -460,7 +460,7 @@ function test_htmlStylerootStatdir () {
     #
 
     $_DAPSEXEC -d $_DCFILE --styleroot=${_DOC_DIR} --fb_styleroot=${_STANDARD_STYLES} --debug html >/dev/null 2>&1
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Fallback Styleroot specified on the command line was not used." \
         "$?"
@@ -481,7 +481,7 @@ function test_htmlStylerootStatdir () {
     # Testing Styleroot specified with --styleroot
     #
     $_DAPSEXEC -d $_DCFILE --styleroot ${_STANDARD_STYLES} --debug html >/dev/null 2>&1
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Styleroot specified on the command line was not used." \
         "$?"

--- a/test/lib/023_text
+++ b/test/lib/023_text
@@ -118,7 +118,7 @@ function test_textRootid () {
 	' └─ Building a text document with --rootid failed ' \
        "$?"
 
-    egrep -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
     assertTrue \
 	' └─ Stringparam for ROOTID is not correctly specified when generating the text file' \
 	"$?"

--- a/test/lib/025_epub
+++ b/test/lib/025_epub
@@ -112,7 +112,7 @@ function test_epubStyleroot () {
     #
 
     $_DAPSEXEC -d $_DCFILE --styleroot=${_DOC_DIR} --fb_styleroot=${_STANDARD_STYLES} --debug epub >/dev/null 2>&1
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Fallback Styleroot specified on the command line was not used." \
         "$?"
@@ -133,7 +133,7 @@ function test_epubStyleroot () {
     # Testing Styleroot specified with --styleroot
     #
     eval "$_DAPSEXEC -d $_DCFILE --styleroot ${_STANDARD_STYLES} --debug epub >/dev/null 2>&1"
-    egrep -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stylesheet /.*/${_STANDARD_STYLES}" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The Styleroot specified on the command line was not used." \
         "$?"
@@ -247,7 +247,7 @@ function test_epubRootid () {
     assertTrue \
         ' └─ Building an EPUB with --rootid failed ' \
        "$?"
-    egrep -q -- "--stringparam\s+\"rootid=${_ROOTID}\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stringparam\s+\"rootid=${_ROOTID}\"" $_LOGFILE 2>/dev/null
     assertTrue \
         ' └─ Stringparam for ROOTID is not correctly specified when generating the EPUB-file' \
         "$?"

--- a/test/lib/033_locdrop
+++ b/test/lib/033_locdrop
@@ -204,7 +204,7 @@ function test_locdropRootid () {
     assertTrue \
         ' └─ Building a locdrop with --rootid failed' \
         "$?"
-    egrep -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
+    grep -E -q -- "--stringparam\s+\"rootid=$_ROOTID\"" $_LOGFILE 2>/dev/null
     assertTrue \
 	' └─ Stringparam for ROOTID is not correctly specified when generating the locdrop' \
 	"$?"

--- a/test/lib/040_asciidoc
+++ b/test/lib/040_asciidoc
@@ -99,7 +99,7 @@ function test_adoc_advanced() {
     assertTrue \
         ' └─ Profiling with $_DCFILE failed' \
         "$?"
-    egrep -q -- "/daps-xslt/asciidoc/postprocess.xsl" $_LOGFILE 2>/dev/null
+    grep -E -q -- "/daps-xslt/asciidoc/postprocess.xsl" $_LOGFILE 2>/dev/null
     assertTrue \
         " └─ The stylesheet for postprocessing the AsciiDoctor-generated XML was not used." \
         "$?"


### PR DESCRIPTION
convert usage of egrep to grep -E boo#1203092

GNU grep 3.8 started to emit warnings when invoking egrep. Replace with grep -E to avoid, and prepare for removal.