### PR TITLE
Fix 676: Add priority=0 in xi:include/@*

### DIFF
--- a/daps-xslt/profiling/base-profile.xsl
+++ b/daps-xslt/profiling/base-profile.xsl
@@ -218,7 +218,12 @@
    </xsl:attribute>
 </xsl:template>
 
-<!-- Remove any non-XInclude attributes -->
-<xsl:template match="xi:include/@*" mode="profile" />
+<!-- Remove any non-XInclude attributes
+
+    Issue #676: add priority="0" to overwrite default priority of 0.5 -> 0
+    The recovery strategy has changed in libxslt >=1.1.35
+    See https://www.w3.org/TR/1999/REC-xslt-19991116#conflict
+-->
+<xsl:template match="xi:include/@*" mode="profile" priority="0" />
 
 </xsl:stylesheet>


### PR DESCRIPTION
For libxslt >=1.1.35, the default selection strategy has been changed (see GNOME/libxslt@b0074ee).

Before libxslt >=1.1.35,  the previous "recovery strategy" was not in accordance to the standard. Now with a more recent version we get two template rules (`xi:include/@href` and `xi:include/@*`) with the same priority (0.5), that's why we need to lower the priority for `xi:include/@*`.