### PR TITLE
Remove superfluous 'format' attribute from 'imagedata'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -403,9 +403,9 @@ Stable release DAPS 2.2.0:
     /etc/daps/docbook-xmlformat.conf.
     (Note: this command will modify the original XML sources!)
   - SVG image support for HTML builds. To use it, make sure to
-    provide the images in SVG format ad reference to them as follows:
+    provide the images in SVG format and reference to them as follows:
     <imageobject role="html">
-     <imagedata fileref="<SVG-FILE>" format="SVG"/>
+     <imagedata fileref="<SVG-FILE>">
     </imageobject>
   - the new global switch --jobs lets you specify how many parallel
     jobs to use. The default is set to the number of CPU cores (as was

--- a/misc/docbook_macros.el
+++ b/misc/docbook_macros.el
@@ -196,10 +196,10 @@
   >"<title>" (skeleton-read "Title: ") "</title>"\n
   >"<mediaobject>"\n
   >"<imageobject role=\"fo\">"\n
-  >"<imagedata fileref=\"" (setq v1 (skeleton-read "Filename: ")) "\" width=\"75%\" format=\"png\"/>"\n
+  >"<imagedata fileref=\"" (setq v1 (skeleton-read "Filename: ")) "\" width=\"75%\"/>"\n
   -1"</imageobject>"\n
   >"<imageobject role=\"html\">"\n
-  >"<imagedata fileref=\""v1"\" width=\"75%\" format=\"png\"/>"\n
+  >"<imagedata fileref=\""v1"\" width=\"75%\"/>"\n
   -1"</imageobject>"\n
   -1"</mediaobject>"\n
   -1"</figure>"\n

--- a/test/documents/xml/appendix.xml
+++ b/test/documents/xml/appendix.xml
@@ -18,7 +18,7 @@
      <title>PNG</title>
      <mediaobject>
       <imageobject>
-       <imagedata fileref="png_example2.png" width="90%" format="PNG"/>
+       <imagedata fileref="png_example2.png" width="90%">
       </imageobject>
      </mediaobject>
     </figure>

--- a/test/documents/xml/not_in_set.xml
+++ b/test/documents/xml/not_in_set.xml
@@ -11,10 +11,10 @@
   <title>Missing Image</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="missing_image_file.png" width="75%" format="png"/>
+    <imagedata fileref="missing_image_file.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="missing_image_file.png" width="75%" format="png"/>
+    <imagedata fileref="missing_image_file.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>


### PR DESCRIPTION
This removes the `"format=…"` attribute from `imagedata` tags. It's only a few occurrences as the templates for `daps init` already don't use 'format'.

I'm not quire sure what to with entities.common.sed. It has some format entries, but they are already commented out