### PR TITLE
Add missing checks for DocBook 5.2

### DIFF
--- a/configure
+++ b/configure
@@ -4550,6 +4550,40 @@ if test -z "$HAVE_DOCBOOK_51"; then
 printf "%s\n" "$as_me: WARNING: Seems you do not have DocBook 5.1 installed." >&2;}
 fi
 
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: ===== Checking for DocBook 5.2..." >&5
+printf "%s\n" "$as_me: ===== Checking for DocBook 5.2..." >&6;}
+for XML_SCHEMA in "http://docbook.org/xml/5.2/rng/docbookxi.rng" \
+                  "http://docbook.org/xml/5.2/rng/docbookxi.rnc" \
+                  "http://docbook.org/xml/5.2/rng/docbook.rng" \
+                  "http://docbook.org/xml/5.2/rng/docbook.rnc" \
+                  "http://docbook.org/xml/5.2/rng/assembly.rng" \
+                  "http://docbook.org/xml/5.2/rng/assembly.rnc" \
+                  "http://docbook.org/xml/5.2/rng/dbits.rng" \
+                  "http://docbook.org/xml/5.2/rng/dbits.rnc"  ; do
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $XML_SCHEMA" >&5
+printf %s "checking for $XML_SCHEMA... " >&6; }
+  if { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$XMLCATALOG --noout \"\$root_catalog\" \"\$XML_SCHEMA\" >&2"; } >&5
+  ($XMLCATALOG --noout "$root_catalog" "$XML_SCHEMA" >&2) 2>&5
+  ac_status=$?
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+    HAVE_DOCBOOK_52=1
+    db5_version="5.2"
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+  fi
+done
+if test -z "$HAVE_DOCBOOK_52"; then
+  HAVE_DOCBOOK_52=0
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Seems you do not have DocBook 5.2 installed." >&5
+printf "%s\n" "$as_me: WARNING: Seems you do not have DocBook 5.2 installed." >&2;}
+fi
+
+
 # In case DocBook 5 is not installed, setting db5_version fails and the
 # URI in etc/config is set to an invalid value. Therefore let's set
 # 5.0 as a hopefully sane default
@@ -7150,6 +7184,35 @@ else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: DocBook 5.1 support              |   yes   |" >&5
 printf "%s\n" "DocBook 5.1 support              |   yes   |" >&6; }
 fi
+
+if test 0 = "$HAVE_DOCBOOK_52"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: DocBook 5.2 support              |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+" >&5
+printf "%s\n" "DocBook 5.2 support              |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: DocBook 5.2 support              |   yes   |" >&5
+printf "%s\n" "DocBook 5.2 support              |   yes   |" >&6; }
+fi
+
+if test 0 = "$HAVE_DOCBOOK_52"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: DocBook Assembly support         |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+" >&5
+printf "%s\n" "DocBook Assembly support         |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: DocBook Assembly support         |   yes   |" >&5
+printf "%s\n" "DocBook Assembly support         |   yes   |" >&6; }
+fi
+
 
 if test 0 = "$ASCIIDOCTOR"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Support AsciiDoc sources         |    no   | install asciidoctor

--- a/configure.ac
+++ b/configure.ac
@@ -505,6 +505,15 @@ else
   AC_MSG_RESULT([DocBook 5.2 support              |   yes   |])
 fi
 
+if test 0 = "$HAVE_DOCBOOK_52"; then
+  AC_MSG_RESULT([DocBook Assembly support         |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+])
+else
+  AC_MSG_RESULT([DocBook Assembly support         |   yes   |])
+fi
+
 
 dnl AsciiDoc support
 if test 0 = "$ASCIIDOCTOR"; then

--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,32 @@ if test -z "$HAVE_DOCBOOK_51"; then
   AC_MSG_WARN([Seems you do not have DocBook 5.1 installed.])
 fi
 
+
+dnl Docbook 5.2
+AC_MSG_NOTICE([===== Checking for DocBook 5.2...])
+for XML_SCHEMA in "http://docbook.org/xml/5.2/rng/docbookxi.rng" \
+                  "http://docbook.org/xml/5.2/rng/docbookxi.rnc" \
+                  "http://docbook.org/xml/5.2/rng/docbook.rng" \
+                  "http://docbook.org/xml/5.2/rng/docbook.rnc" \
+                  "http://docbook.org/xml/5.2/rng/assembly.rng" \
+                  "http://docbook.org/xml/5.2/rng/assembly.rnc" \
+                  "http://docbook.org/xml/5.2/rng/dbits.rng" \
+                  "http://docbook.org/xml/5.2/rng/dbits.rnc"  ; do
+  AC_MSG_CHECKING([for $XML_SCHEMA])
+  if AC_RUN_LOG([$XMLCATALOG --noout "$root_catalog" "$XML_SCHEMA" >&2]); then
+    AC_MSG_RESULT([yes])
+    HAVE_DOCBOOK_52=1
+    db5_version="5.2"
+  else
+    AC_MSG_RESULT([no])
+  fi
+done
+if test -z "$HAVE_DOCBOOK_52"; then
+  HAVE_DOCBOOK_52=0
+  AC_MSG_WARN([Seems you do not have DocBook 5.2 installed.])
+fi
+
+
 # In case DocBook 5 is not installed, setting db5_version fails and the
 # URI in etc/config is set to an invalid value. Therefore let's set
 # 5.0 as a hopefully sane default
@@ -469,6 +495,16 @@ if test 0 = "$HAVE_DOCBOOK_51"; then
 else
   AC_MSG_RESULT([DocBook 5.1 support              |   yes   |])
 fi
+
+if test 0 = "$HAVE_DOCBOOK_52"; then
+  AC_MSG_RESULT([DocBook 5.2 support              |    no   | install DocBook 5.2, the
+                                 |         | DocBook 5 XSL stylesheets,
+                                 |         | and jing
+])
+else
+  AC_MSG_RESULT([DocBook 5.2 support              |   yes   |])
+fi
+
 
 dnl AsciiDoc support
 if test 0 = "$ASCIIDOCTOR"; then


### PR DESCRIPTION
The configure script doesn't check for DocBook 5.2. I've added the necessary checks in the `configure.ac` file. However, ATM, I can't recreate `configure` as I don't have the latest version of `autoconf`. Probably you may want to rebuild it.

@fsundermeyer, maybe this could be a bugfix for the upcoming DAPS 4.0?