### PR TITLE
Use 100 char line length for XML sources (SUSE/doc-styleguide#141)

### DIFF
--- a/etc/docbook-xmlformat-1.9.conf
+++ b/etc/docbook-xmlformat-1.9.conf
@@ -35,7 +35,7 @@ para abstract
   exit-break   1
   normalize    yes
   wrap-type    length
-  wrap-length  79
+  wrap-length  99
 
 
 title term


### PR DESCRIPTION
Fixes part 2 of https://github.com/SUSE/doc-styleguide/issues/141