### PR TITLE
Find empty inline elements in our sources

### DIFF
--- a/contrib/check-source/find-empty-inlines.xsl
+++ b/contrib/check-source/find-empty-inlines.xsl
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Purpose:
+     Find empty inline elements in our sources.
+     These elements cause layout issues in HTML.
+
+   Input:
+     DocBook 5 document
+
+   Output:
+     Text output or nothing
+     The XPath doesn't take into account namespaces. You can assume, all
+     element names are bound to the DocBook 5 namespace.
+
+   Author:
+     Thomas Schraitle <toms@opensuse.org>
+
+   Copyright (C) 2023 SUSE Linux GmbH
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:import href="xpath.location.xsl"/>
+  <xsl:output method="text"/>
+
+  <xsl:strip-space elements="*"/>
+  <xsl:preserve-space elements="d:screen d:programlisting"/>
+
+
+  <xsl:template name="error">
+    <xsl:param name="id">
+      <xsl:choose>
+        <xsl:when test="ancestor-or-self::*/@xml:id[last()]">
+          <xsl:value-of select="ancestor-or-self::*/@xml:id[last()]"/>
+        </xsl:when>
+        <xsl:otherwise>n/a</xsl:otherwise>
+      </xsl:choose>
+    </xsl:param>
+    <xsl:param name="title" select="(ancestor-or-self::*/d:title|ancestor-or-self::*/d:info/d:title)[last()]"/>
+    <xsl:param name="node" select="."/>
+
+    <xsl:message>[ERROR] Empty inline <xsl:value-of 
+      select="concat('&lt;', local-name($node), '>')"/> found near id=<xsl:value-of
+        select="$id"/>, title=<xsl:value-of select="normalize-space($title)"/>
+        XPath=<xsl:call-template name="xpath.location"/>
+    </xsl:message>
+  </xsl:template>
+
+
+  <!-- Templates -->
+  <xsl:template match="text()"/>
+
+  <xsl:template match="d:abbrev|d:accel|d:acronym|d:alt|d:arg|d:bridgehead|
+                       d:buildtarget|d:citation|d:citebiblioid|d:citerefentry|
+                       d:citetitle|d:city|d:classname|d:code|d:command|
+                       d:computeroutput|d:confdates|d:confgroup|d:confnum|
+                       d:confsponsor|d:conftitle|d:constant|d:constraint|
+                       d:contractnum|d:contractsponsor|d:contrib|
+                       d:copyright|d:country|d:database|d:edition|
+                       d:email|d:enumidentifier|d:enumitemdescription|d:enumname|
+                       d:enumvalue|d:envar|d:errorcode|d:errorname|d:errortext|
+                       d:errortype|d:exceptionname|d:fax|d:filename|d:firstname|
+                       d:foreignphrase|d:funcdef|d:function|d:guilabel|d:guimenu|
+                       d:guimenuitem|d:guisubmenu|d:hardware|d:holder|d:honorific|
+                       d:initializer|d:issuenum|d:jobtitle|d:keycode|d:keysym|
+                       d:keyword|d:label|d:lhs|d:lineage|d:lineannotation|
+                       d:literal|d:macrodef|d:macroname|d:manvolnum|d:markup|
+                       d:mathphrase|d:member|d:modfier|d:msgaud|d:msglevel|d:msgtext|
+                       d:nonterminal|d:ooclass|d:ooexception|d:oointerface|
+                       d:option|d:optional|d:org|d:orgdiv|d:orgname|d:otheraddr|
+                       d:othername|d:package|d:pagenums|d:paramdef|d:parameter|
+                       d:phone|d:pob|d:postcode|d:primary|d:primarie|d:prompt|
+                       d:property|d:publisher|d:publishername|d:quote|d:refclass|
+                       d:refname|d:refpurpose|d:remark|d:replaceable|d:returnvalue|
+                       d:rhs|d:segtitle|d:seriesvolnums|d:state|d:street|d:subjectterm|
+                       d:surname|d:systemitem|d:tag|d:tertiary|d:tertiaryie|d:title|
+                       d:token|d:type|d:typedefname|d:unionname|d:uri|d:varname|d:volumenum|
+                       d:year
+                       ">
+    <xsl:choose>
+      <xsl:when test="normalize-space(.) = ''">
+        <xsl:call-template name="error"/>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/contrib/check-source/xpath.location.xsl
+++ b/contrib/check-source/xpath.location.xsl
@@ -1,0 +1,1 @@
+../../daps-xslt/common/xpath.location.xsl

--- a/daps-xslt/common/xpath.location.xsl
+++ b/daps-xslt/common/xpath.location.xsl
@@ -2,41 +2,41 @@
 <!-- 
    Purpose:
      Returns the XPath of a node, including predicates if needed
-     
+
    Parameters:
      None
-     
+
    Dependencies:
-       None
-   
+     None
+
    Keys:
      None
-       
+
    Input:
      DocBook 4, 5, or Novdoc documents
-     
+
    Output:
-     string of 
-   
+     string of XPath
+
    Author:    Thomas Schraitle <toms@opensuse.org>
    Copyright (C) 2015 SUSE Linux GmbH
 
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<!-- 
+<!--
    Original template from http://docbook.sourceforge.net/release/xsl/current/lib/lib.xsl
--->    
-    
+--> 
+
     <xsl:template name="xpath.location">
         <xsl:param name="node" select="."/>
         <xsl:param name="path" select="''"/>
-        
+
         <xsl:variable name="fo-sib"
             select="count($node/following-sibling::*[name(.) = name($node)])"/>
         <xsl:variable name="prec-sib"
             select="count($node/preceding-sibling::*[name(.) = name($node)])"/>
-        
+
         <xsl:variable name="next.path">
             <xsl:value-of select="local-name($node)"/>
             <xsl:if test="$path != ''">
@@ -47,7 +47,7 @@
             </xsl:if>
             <xsl:value-of select="$path"/>
         </xsl:variable>
-        
+
         <xsl:choose>
             <xsl:when test="$node/parent::*">
                 <xsl:call-template name="xpath.location">
@@ -60,6 +60,6 @@
                 <xsl:value-of select="$next.path"/>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:template>    
-    
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
These empty inlines cause layout issues in HTML.

This can help to find issues in translated files.