### PR TITLE
When --debug, output assembly properties

### DIFF
--- a/make/debug.mk
+++ b/make/debug.mk
@@ -59,6 +59,11 @@ ROOTID             = $(ROOTID)\n\
 STYLEIMG           = $(STYLEIMG)\n\
 STYLEROOT          = $(STYLEROOT)\n\
 \n\
+Assemblies\n\
+----------
+STYLEASSEMBLY      = $(STYLEASSEMBLY)\n\
+STRUCTID           = $(STRUCTID)\n\
+\n\
 Profiling\n\
 ---------\n\
 PROFILE_URN        = $(PROFILE_URN)\n\


### PR DESCRIPTION
This PR contains a minor change to output the content of the `STYLEASSEMBLY` and `STRUCTID` variables.

I'm not completely sure if this is the right place. I think it could be beneficial as we are using more and more assemblies.