### PR TITLE
Fixed xmlformat config to work with Debian

### DIFF
--- a/etc/docbook-xmlformat-1.04.conf
+++ b/etc/docbook-xmlformat-1.04.conf
@@ -4,7 +4,7 @@
 #
 
 *DEFAULT
-￼  subindent   2
+  subindent  2
 
 # Block elements
 ackno address appendix article biblioentry bibliography bibliomixed \


### PR DESCRIPTION
The indentation in the config file seems to matter as Debian refused to indent 2 by default