### PR TITLE
Remove all xml:base attributes from the XML input

### DIFF
--- a/daps-xslt/contrib/remove-xml-base.xsl
+++ b/daps-xslt/contrib/remove-xml-base.xsl
@@ -1,0 +1,34 @@
+<!-- 
+   Purpose:
+     Remove all xml:base attributes from the input without changing the
+     formatting (especially useful for <screen> elements)
+
+   Parameters:
+     * None
+
+   Input:
+     DocBook document
+
+   Output:
+     A document without any xml:base attributes
+
+   Author:    Tom Schraitle <toms@opensuse.org>
+   Date:      2025, Jan
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="no"/>
+
+  <!-- Just in case... -->
+  <xsl:preserve-space elements="screen"/>
+
+  <!-- Match and remove all xml:base attributes -->
+  <xsl:template match="@xml:base"/>
+
+  <!-- Copy all other elements and text nodes -->
+  <xsl:template match="node()">
+    <xsl:copy>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
When using `xmlstarlet ed -d '//@xml:base'`, the result XML is formatted. Unfortunately, this destroys the indentation for `<screen>` elements. As `xmlstarlet` doesn't have any options to avoid that, we can only use a XSLT stylesheet.

This stylesheet is an attempt to replace above `xmlstarlet ed` but preserves the indendation.

Needed for locdrop as described in https://confluence.suse.com/display/documentation/Loc+drop+for+Smart+Docs