### PR TITLE
GHA: Change Ubuntu 20.04 to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           sudo apt-get install -y --fix-missing autoconf \
                               automake \
                               autotools-dev \
-                              checkbot \
                               dia \
                               docbook \
                               docbook-xml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Output env variables
         run: |


### PR DESCRIPTION
Reason:
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details https://github.com/actions/runner-images/issues/11101