### PR TITLE
Convert a an empty book/preface/title into abstract

### DIFF
--- a/daps-xslt/asciidoc/postprocess.xsl
+++ b/daps-xslt/asciidoc/postprocess.xsl
@@ -298,7 +298,6 @@
     </xsl:if>
   </xsl:template>
 
-
   <!-- HINT: Turn a <orderedlist role="procedure"> into a real <procedure>
 
       In ADoc you use this syntax:
@@ -384,5 +383,33 @@
     <!-- With enumeration we switch to a normal orderedlist, not substeps. -->
     <xsl:apply-templates select="." />
   </xsl:template>
+
+  <!-- Structure -->
+
+  <xsl:template match="d:book[normalize-space(d:preface/d:title) = '']">
+    <xsl:copy>
+      <xsl:copy-of select="@*" />
+      <info>
+        <xsl:apply-templates select="d:info/node()"/>
+        <xsl:apply-templates select="d:preface" mode="book-preface" />
+      </info>
+      <xsl:apply-templates select="node()[not(self::d:info)]" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="*" mode="book-preface">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()" mode="book-preface" />
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="d:preface/d:title" mode="book-preface" />
+  <xsl:template match="d:preface" mode="book-preface">
+    <abstract>
+      <xsl:apply-templates mode="book-preface" />
+    </abstract>
+  </xsl:template>
+
+  <xsl:template match="d:book[normalize-space(d:preface/d:title) = '']/d:preface" />
+
 
 </xsl:stylesheet>


### PR DESCRIPTION
# Background

When transforming SUSE AI (for example, `DC-AI-deployment`) into a bigfile, you end up with this structure:

```xml
<book ...>
  <info> ... </info>
  <preface>
     <title />
     <variablelist> <!-- What, why, effort, and goal --> </variablelist>
  </preface>

  <!-- rest of the book -->
</book>
```

## Effect

The empty preface title leads to an odd empty link in the left side TOC. Additionally, the title vanishes.

## Proposal

This fix adds additional templates that deals with an empty preface title. If the stylesheet detects such structure, it moves everything inside the `<preface>` moved into an `<abstract>` placed inside an `<info>`.

This is the usual structure we have with Smart Docs.