### PR TITLE
Fix preface when using ADoc [preface] role

### DIFF
--- a/daps-xslt/asciidoc/postprocess.xsl
+++ b/daps-xslt/asciidoc/postprocess.xsl
@@ -391,25 +391,39 @@
       <xsl:copy-of select="@*" />
       <info>
         <xsl:apply-templates select="d:info/node()"/>
-        <xsl:apply-templates select="d:preface" mode="book-preface" />
+        <xsl:comment> Abstract:</xsl:comment>
+        <xsl:apply-templates select="d:preface/d:variablelist|d:preface/d:abstract/d:variablelist" mode="book-preface" />
       </info>
       <xsl:apply-templates select="node()[not(self::d:info)]" />
     </xsl:copy>
   </xsl:template>
+
 
   <xsl:template match="*" mode="book-preface">
     <xsl:copy>
       <xsl:apply-templates select="@* | node()" mode="book-preface" />
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="d:preface/d:title" mode="book-preface" />
-  <xsl:template match="d:preface" mode="book-preface">
-    <abstract>
-      <xsl:apply-templates mode="book-preface" />
+
+  <xsl:template match="d:simpara" mode="book-preface">
+    <para>
+      <xsl:apply-templates select="@* | node()" mode="book-preface" />
+    </para>
+  </xsl:template>
+
+  <xsl:template match="d:preface[normalize-space(d:title) = '']/d:title" mode="book-preface" />
+
+  <xsl:template match="d:preface/d:variablelist | d:preface/d:abstract/d:variablelist" mode="book-preface">
+     <abstract>
+       <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="book-preface" />
+       </xsl:copy>
     </abstract>
   </xsl:template>
 
-  <xsl:template match="d:book[normalize-space(d:preface/d:title) = '']/d:preface" />
+  <xsl:template match="d:book/d:preface[normalize-space(d:title) = '']" >
+    <xsl:message>Ignore empty preface</xsl:message>
+  </xsl:template>
 
 
 </xsl:stylesheet>


### PR DESCRIPTION
* Copy a real ADoc preface as DocBook preface
* Only use the variablelist in an empty preface[title='']. This goes into an <abstract> inserted in <info>

This separates the abstarct info and the real preface info. From `articles/ai-requirements.adoc`:

```adoc
[abstract]
--
WHAT?::
   Hardware, software and network
WHY?::
  To ensure efficient operation of {productname}.

----

[preface]
== Preface
This article describes the software, hardware and networking requirements for the cluster nodes where you plan to install {productname}.
```