### PR TITLE
Bugfix: use `type -p` instead of `which` in check_prg()

### DIFF
--- a/bin/daps-check-deps
+++ b/bin/daps-check-deps
@@ -9,7 +9,7 @@
 #
 
 function check_prg {
-    which $1 2>/dev/null || return 1
+    type -p $1 2>/dev/null || return 1
 }
 
 function print_prg {


### PR DESCRIPTION
On systems without the `which` binary (e. g. Tumbleweed Minimal) daps-check-deps reports installed programs as missing. As daps-check-deps is a bash script it's safer to use the bash builtin `type -p`.