### PR TITLE
Allow configuring the Python interpreter

### DIFF
--- a/bin/daps.in
+++ b/bin/daps.in
@@ -128,6 +128,7 @@ VARLIST=(
     PROFUSERLEVEL
     PROFVENDOR
     PROFWORDSIZE
+    PYTHON
     REMARKS
     REMARK_STR
     RESULT_DIR
@@ -1742,7 +1743,7 @@ fi
 # well-formedness and not for validity (a DocBook 5 validity check would
 # require jing).
 
-CHECK_WELLFORMED=$(PYTHONWARNINGS="ignore" ${LIBEXEC_DIR}/daps-xmlwellformed --xinclude ${MAIN} 2>&1)
+CHECK_WELLFORMED=$(PYTHONWARNINGS="ignore" $PYTHON ${LIBEXEC_DIR}/daps-xmlwellformed --xinclude ${MAIN} 2>&1)
 
 if [[ 0 -ne $? ]]; then
     # sometimes daps-xmnlwellformed stumbles upon errors and does not produce

--- a/etc/config.in
+++ b/etc/config.in
@@ -781,6 +781,21 @@ PROFOUTPUTFORMAT=""
 #
 PROFVENDOR=""
 
+## Key:         PYTHON
+## -------------------
+## Description: Interpreter used to run the Python helper scripts
+## Type:        Path to executable
+## Default:     ""
+#
+# DAPS uses Python helper scripts to check XML files for well-formedness,
+# to validate tables and to determine the entity files used by a document.
+# When this value is empty, these scripts are called directly and therefore
+# run with the interpreter specified in their shebang line.
+# Set this variable to run them with a different interpreter, for example
+# one from a virtual environment providing the required lxml module.
+#
+PYTHON=""
+
 ## Key:         REMARK
 ## -------------------
 ## Description: Generate books with remarks?

--- a/lib/unpack-locdrop
+++ b/lib/unpack-locdrop
@@ -212,7 +212,7 @@ function unpack-locdrop {
     # Get entity files from the notrans sources and link to them
     #
     echo "Getting entities"
-    ENTITIES="$("${LIBEXEC_DIR}/getentityname.py" ${P_NOTRANS_DIR}/xml/*.xml)"
+    ENTITIES="$($PYTHON "${LIBEXEC_DIR}/getentityname.py" ${P_NOTRANS_DIR}/xml/*.xml)"
     for ENT in $ENTITIES; do
         if [[ -f $ENT ]]; then
             [[ 1 -eq $DEBUG ]] && echo "Linking ${P_NOTRANS_DIR}/xml/$ENT"

--- a/make/setfiles.mk
+++ b/make/setfiles.mk
@@ -97,9 +97,9 @@ endif
 # Entity files
 #
 ifeq "$(strip $(IS_ASSEMBLY))" "assembly"
-  ENTITIES_DOC := $(shell $(LIBEXEC_DIR)/getentityname.py $(ASSEMBLYFILES) $(ASSEMBLY_MAIN) 2>/dev/null)
+  ENTITIES_DOC := $(shell $(PYTHON) $(LIBEXEC_DIR)/getentityname.py $(ASSEMBLYFILES) $(ASSEMBLY_MAIN) 2>/dev/null)
 else
-  ENTITIES_DOC := $(shell $(LIBEXEC_DIR)/getentityname.py $(DOCFILES) 2>/dev/null)
+  ENTITIES_DOC := $(shell $(PYTHON) $(LIBEXEC_DIR)/getentityname.py $(DOCFILES) 2>/dev/null)
 endif
 
 # this does not resolve links

--- a/make/validate.mk
+++ b/make/validate.mk
@@ -66,7 +66,7 @@ $(PROFILEDIR)/.validate validate: $(PROFILES)
 	$(eval FAULTY_XML=$(shell unset VERBOSE && $(JING_WRAPPER) $(JING_FLAGS) $(DOCBOOK5_RNG) $(PROFILED_MAIN) 2>&1))
   endif
   ifeq "$(strip $(VALIDATE_TABLES))" "1"
-	$(eval FAULTY_TABLES=$(shell $(LIBEXEC_DIR)/validate-tables.py $(PROFILED_MAIN) 2>&1 | sed -r -e 's,^/([^/: ]+/)*,,' -e 's,.http://docbook.org/ns/docbook.,,' | sed -rn '/^- / !p' | awk -v ORS='\\n' '1'))
+	$(eval FAULTY_TABLES=$(shell $(PYTHON) $(LIBEXEC_DIR)/validate-tables.py $(PROFILED_MAIN) 2>&1 | sed -r -e 's,^/([^/: ]+/)*,,' -e 's,.http://docbook.org/ns/docbook.,,' | sed -rn '/^- / !p' | awk -v ORS='\\n' '1'))
   endif
   ifeq "$(strip $(VALIDATE_IDS))" "1"
 	$(eval FAULTY_IDS=$(shell $(XSLTPROC) --xinclude --stylesheet $(DAPSROOT)/daps-xslt/common/get-all-xmlids.xsl --file $(PROFILED_MAIN) $(XSLTPROCESSOR) | grep -P '[^-a-zA-Z0-9]'))


### PR DESCRIPTION
Hi, this PR make it possible to set the Python interpreter using `~/.config/daps/dapsrc` or in DC file. Environment variable is not respected which seems to be true for _all_ DAPS configuration options for some reason.

```rc
PYTHON=".venv/bin/python"
```

I did not add `--python` or any similar command-line arguments.

This makes it easier to package for systems like NixOS, or to make it easy to use different than system Python in case something breaks (case in point: Tumbleweed recently removed the `python311-lxml` package, breaking DAPS, see https://suse.slack.com/archives/C02DEAP3U5P/p1788274848540109).

I tested building on Tumbleweed and NixOS. There's a package using this change in https://build.suse.de/package/show/home:LKucharczyk:branches:Documentation:Tools/daps but currently blocked.